### PR TITLE
feat: Add tool named getPage

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ A Model Context Protocol (MCP) server that connects AI models to GROWI wiki cont
 - `deletePages` - Delete pages (bulk operation supported)
 - `duplicatePage` - Duplicate a page (including child pages)
 - `renamePage` - Change page name and path
+- `getPage` - Get a page data
 - `getPageInfo` - Get detailed page information
 - `getRecentPages` - Get list of recently updated pages
 - `getPageListingRoot` - Get root page list

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ A Model Context Protocol (MCP) server that connects AI models to GROWI wiki cont
 
 1. Clone the repository
 ```bash
-git clone https://github.com/weseek/growi-mcp-server.git
+git clone https://github.com/growilabs/growi-mcp-server.git
 cd growi-mcp-server
 ```
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -101,7 +101,7 @@ GROWI wiki コンテンツにAIモデルを接続するModel Context Protocol (M
 
 1. リポジトリをクローン
 ```bash
-git clone https://github.com/weseek/growi-mcp-server.git
+git clone https://github.com/growilabs/growi-mcp-server.git
 cd growi-mcp-server
 ```
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -49,6 +49,7 @@ GROWI wiki コンテンツにAIモデルを接続するModel Context Protocol (M
 - `deletePages` - ページを削除（一括対応）
 - `duplicatePage` - ページを複製（子ページも含む）
 - `renamePage` - ページ名とパスを変更
+- `getPage` - ページの内容を取得
 - `getPageInfo` - ページの詳細情報を取得
 - `getRecentPages` - 最近更新されたページ一覧
 - `getPageListingRoot` - ルートページ一覧を取得

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "dotenv-flow": "^4.1.0",
     "fastmcp": "^2.0.0",
+    "ky": "^1.8.1",
     "zod": "^3.25.7"
   },
   "devDependencies": {

--- a/src/tools/page/getPage/index.ts
+++ b/src/tools/page/getPage/index.ts
@@ -1,0 +1,1 @@
+export { registerGetPageTool } from './register';

--- a/src/tools/page/getPage/register.ts
+++ b/src/tools/page/getPage/register.ts
@@ -1,0 +1,42 @@
+import apiv3 from '@growi/sdk-typescript/v3';
+import type { FastMCP } from 'fastmcp';
+import { UserError } from 'fastmcp';
+import { z } from 'zod';
+import { getPageParamSchema } from './schema.js';
+
+export function registerGetPageTool(server: FastMCP): void {
+  server.addTool({
+    name: 'getPage',
+    description: 'Get page data about the specific GROWI page',
+    parameters: getPageParamSchema,
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+      title: 'Get Page',
+    },
+    execute: async (params) => {
+      try {
+        // Validate parameters
+        const validatedParams = getPageParamSchema.parse(params);
+
+        // Execute operation using SDK
+        const page = await apiv3.getPage(validatedParams);
+        return JSON.stringify(page);
+      } catch (error) {
+        // Handle validation errors
+        if (error instanceof z.ZodError) {
+          throw new UserError('Invalid parameters provided', {
+            validationErrors: error.errors,
+          });
+        }
+
+        // Handle unexpected errors
+        throw new UserError('Failed to get page', {
+          originalError: error instanceof Error ? error.message : String(error),
+        });
+      }
+    },
+  });
+}

--- a/src/tools/page/getPage/schema.ts
+++ b/src/tools/page/getPage/schema.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+export const getPageParamSchema = z.object({
+  pageId: z.string().optional().describe('ID of the GROWI page'),
+  path: z.string().optional().describe('Path of the GROWI page'),
+});
+
+export type GetPageParam = z.infer<typeof getPageParamSchema>;

--- a/src/tools/page/index.ts
+++ b/src/tools/page/index.ts
@@ -2,6 +2,7 @@ import type { FastMCP } from 'fastmcp';
 import { registerCreatePageTool } from './createPage';
 import { registerDeletePagesTool } from './deletePages';
 import { registerDuplicatePageTool } from './duplicatePages';
+import { registerGetPageTool } from './getPage';
 import { registerGetPageInfoTool } from './getPageInfo';
 import { registerGetPageListingChildrenTool } from './getPageListingChildren';
 import { registerGetPageListingRootTool } from './getPageListingRoot';
@@ -24,6 +25,7 @@ export async function loadPageTools(server: FastMCP): Promise<void> {
   registerUnpublishPageTool(server);
   registerDuplicatePageTool(server);
   registerPageListingInfoTool(server);
+  registerGetPageTool(server);
   registerGetPageInfoTool(server);
   registerGetPageListingChildrenTool(server);
   registerGetPageListingRootTool(server);


### PR DESCRIPTION
## Summary
- Added a new tool called getPage to retrieve a specific page from GROWI.
  The parameters follow the API v3 specification for the "Get page" operation:
  https://docs.growi.org/redoc-apiv3.html#tag/Page/operation/getPage
- Updated the repository URL in the README to point to this repository.
- Added the existing dependency ky to package.json (it was already in use before this change).

## Testing
- Build and lint checks: Passed
- Verified functionality using the MCP CLI: Succed
- Confirmed that the tool works in the production environment and can be called from the MCP client: Succed

---
[JP: 日本語訳]
## Summary
- GROWIの指定ページを取得するツール「getPage」を追加しました。
  パラメータはAPI v3のGet pageに準拠しています。
  https://docs.growi.org/redoc-apiv3.html#tag/Page/operation/getPage
- READMEのリポジトリのURLを本リポジトリのものに修正しました。
- 今回の変更前の時点で存在した依存パッケージ（ky）をpackage.jsonへ追記しました。

## Testing
- ビルド, リント：通過することを確認済み
- MCP CLIで動作確認：済
- 本番環境での実行：MCPクライアントからも呼び出せることを確認済み
