### PR TITLE
feat: Enable operations on multiple registered app

### DIFF
--- a/src/tools/comments/getComments/register.ts
+++ b/src/tools/comments/getComments/register.ts
@@ -2,6 +2,7 @@ import apiv1 from '@growi/sdk-typescript/v1';
 import type { FastMCP } from 'fastmcp';
 import { UserError } from 'fastmcp';
 import { z } from 'zod';
+import { resolveAppName } from '../../../commons/utils/resolve-app-name.js';
 import { getCommentsParamSchema } from './schema.js';
 
 export function registerGetCommentsTool(server: FastMCP): void {
@@ -19,16 +20,17 @@ export function registerGetCommentsTool(server: FastMCP): void {
     execute: async (params) => {
       try {
         // Validate parameters
-        const validatedParams = getCommentsParamSchema.parse(params);
+        const { appName, ...getCommentsParams } = getCommentsParamSchema.parse(params);
+        const resolvedAppName = resolveAppName(appName);
 
         // Prepare API parameters
         const apiParams = {
-          page_id: validatedParams.pageId,
-          ...(validatedParams.revisionId && { revision_id: validatedParams.revisionId }),
+          page_id: getCommentsParams.pageId,
+          ...(getCommentsParams.revisionId && { revision_id: getCommentsParams.revisionId }),
         };
 
         // Execute operation using SDK
-        const result = await apiv1.getComments(apiParams);
+        const result = await apiv1.getComments(apiParams, { appName: resolvedAppName });
 
         return JSON.stringify(result);
       } catch (error) {

--- a/src/tools/comments/getComments/schema.ts
+++ b/src/tools/comments/getComments/schema.ts
@@ -1,8 +1,12 @@
 import { z } from 'zod';
+import { appNameSchema } from '../../commons/app-name-schemas';
 
 export const getCommentsParamSchema = z.object({
   pageId: z.string().describe('ID of the page to get comments for'),
   revisionId: z.string().optional().describe('ID of the revision to get comments for (optional)'),
+
+  // Name used to identify the GROWI App registered with the MCP Server
+  ...appNameSchema.shape,
 });
 
 export type GetCommentsParam = z.infer<typeof getCommentsParamSchema>;

--- a/src/tools/page/deletePages/register.ts
+++ b/src/tools/page/deletePages/register.ts
@@ -2,6 +2,7 @@ import type { FastMCP } from 'fastmcp';
 import { UserError } from 'fastmcp';
 import { z } from 'zod';
 import { isGrowiApiError } from '../../../commons/api/growi-api-error.js';
+import { resolveAppName } from '../../../commons/utils/resolve-app-name.js';
 import { deletePagesParamSchema } from './schema.js';
 import { deletePages } from './service.js';
 
@@ -17,10 +18,11 @@ export function registerDeletePagesTool(server: FastMCP): void {
     execute: async (params) => {
       try {
         // Validate parameters
-        const validatedParams = deletePagesParamSchema.parse(params);
+        const { appName, ...deletePagesParams } = deletePagesParamSchema.parse(params);
+        const resolvedAppName = resolveAppName(appName);
 
         // Execute service operation with validated parameters
-        const response = await deletePages(validatedParams);
+        const response = await deletePages(deletePagesParams, resolvedAppName);
         return JSON.stringify(response);
       } catch (error) {
         // Handle validation errors

--- a/src/tools/page/deletePages/schema.ts
+++ b/src/tools/page/deletePages/schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { appNameSchema } from '../../commons/app-name-schemas';
 
 const deleteOptionsSchema = z.object({
   isCompletely: z.boolean(),
@@ -13,6 +14,9 @@ export const deletePagesParamSchema = z.object({
   isCompletely: z.boolean().optional().describe('Whether to completely delete the pages'),
   isRecursively: z.boolean().optional().describe('Whether to delete child pages recursively'),
   isAnyoneWithTheLink: z.boolean().optional().describe('Whether to delete pages accessible by anyone with the link'),
+
+  // Name used to identify the GROWI App registered with the MCP Server
+  ...appNameSchema.shape,
 });
 
 export type DeletePagesParam = z.infer<typeof deletePagesParamSchema>;

--- a/src/tools/page/deletePages/service.ts
+++ b/src/tools/page/deletePages/service.ts
@@ -5,7 +5,7 @@ import type { PostDeleteForPagesBody } from '@growi/sdk-typescript/v3';
 import { GrowiApiError } from '../../../commons/api/growi-api-error.js';
 import type { DeletePagesParam, DeletePagesResponse } from './schema.js';
 
-export const deletePages = async (params: DeletePagesParam): Promise<DeletePagesResponse> => {
+export const deletePages = async (params: DeletePagesParam, appName: string): Promise<DeletePagesResponse> => {
   try {
     // Get the number of pages to delete
     const pageCount = Object.keys(params.pageIdToRevisionIdMap).length;
@@ -22,7 +22,7 @@ export const deletePages = async (params: DeletePagesParam): Promise<DeletePages
         recursively: params.isRecursively || undefined,
       };
 
-      const response = await apiv1.removePage(removePageBody);
+      const response = await apiv1.removePage(removePageBody, { appName });
 
       return {
         paths: [response.path],
@@ -39,7 +39,7 @@ export const deletePages = async (params: DeletePagesParam): Promise<DeletePages
       isAnyoneWithTheLink: params.isAnyoneWithTheLink || undefined,
     };
 
-    const response = await apiv3.postDeleteForPages(postDeleteBody);
+    const response = await apiv3.postDeleteForPages(postDeleteBody, { appName });
 
     if (!response.paths) {
       throw new GrowiApiError('The API response is missing required data', 500);

--- a/src/tools/page/duplicatePages/register.ts
+++ b/src/tools/page/duplicatePages/register.ts
@@ -2,6 +2,7 @@ import { type FastMCP, UserError } from 'fastmcp';
 import { ZodError } from 'zod';
 
 import { GrowiApiError } from '../../../commons/api/growi-api-error';
+import { resolveAppName } from '../../../commons/utils/resolve-app-name.js';
 import { duplicatePageSchema } from './schema';
 import { duplicatePage } from './service';
 
@@ -20,10 +21,11 @@ export const registerDuplicatePageTool = (server: FastMCP): void => {
     execute: async (params) => {
       try {
         // Validate params using zod schema
-        const validatedParams = duplicatePageSchema.parse(params);
+        const { appName, ...duplicatePageParams } = duplicatePageSchema.parse(params);
+        const resolvedAppName = resolveAppName(appName);
 
         // Execute duplication
-        const duplicatedPage = await duplicatePage(validatedParams);
+        const duplicatedPage = await duplicatePage(duplicatePageParams, resolvedAppName);
 
         return JSON.stringify({
           status: 'success',

--- a/src/tools/page/duplicatePages/schema.ts
+++ b/src/tools/page/duplicatePages/schema.ts
@@ -1,5 +1,6 @@
 import type { PostDuplicateForPagesBody } from '@growi/sdk-typescript/v3';
 import { z } from 'zod';
+import { appNameSchema } from '../../commons/app-name-schemas';
 
 // Input schema
 export const duplicatePageSchema = z.object({
@@ -7,6 +8,9 @@ export const duplicatePageSchema = z.object({
   pageNameInput: z.string().optional(),
   isRecursively: z.boolean().optional().default(false),
   onlyDuplicateUserRelatedResources: z.boolean().optional().default(false),
+
+  // Name used to identify the GROWI App registered with the MCP Server
+  ...appNameSchema.shape,
 });
 
 export type DuplicatePageParams = z.infer<typeof duplicatePageSchema>;

--- a/src/tools/page/duplicatePages/service.ts
+++ b/src/tools/page/duplicatePages/service.ts
@@ -3,14 +3,17 @@ import type { Page } from '@growi/sdk-typescript/v3';
 import { GrowiApiError } from '../../../commons/api/growi-api-error';
 import type { DuplicatePageParams } from './schema';
 
-export const duplicatePage = async (params: DuplicatePageParams): Promise<Page> => {
+export const duplicatePage = async (params: DuplicatePageParams, appName: string): Promise<Page> => {
   try {
     // Check if target path exists
     if (params.pageNameInput) {
       // Check if page exists
-      const existResponse = await apiv3.getExistForPage({
-        path: params.pageNameInput,
-      });
+      const existResponse = await apiv3.getExistForPage(
+        {
+          path: params.pageNameInput,
+        },
+        { appName },
+      );
 
       // If path exists, throw error
       if (existResponse.isExist) {
@@ -19,12 +22,15 @@ export const duplicatePage = async (params: DuplicatePageParams): Promise<Page> 
     }
 
     // Execute duplicate operation
-    const result = await apiv3.postDuplicateForPages({
-      pageId: params.pageId,
-      pageNameInput: params.pageNameInput,
-      isRecursively: params.isRecursively,
-      onlyDuplicateUserRelatedResources: params.onlyDuplicateUserRelatedResources,
-    });
+    const result = await apiv3.postDuplicateForPages(
+      {
+        pageId: params.pageId,
+        pageNameInput: params.pageNameInput,
+        isRecursively: params.isRecursively,
+        onlyDuplicateUserRelatedResources: params.onlyDuplicateUserRelatedResources,
+      },
+      { appName },
+    );
 
     if (!result.page) {
       throw new GrowiApiError('Failed to duplicate page: Response data is invalid', 500);

--- a/src/tools/page/getPage/register.ts
+++ b/src/tools/page/getPage/register.ts
@@ -2,6 +2,7 @@ import apiv3 from '@growi/sdk-typescript/v3';
 import type { FastMCP } from 'fastmcp';
 import { UserError } from 'fastmcp';
 import { z } from 'zod';
+import { resolveAppName } from '../../../commons/utils/resolve-app-name.js';
 import { getPageParamSchema } from './schema.js';
 
 export function registerGetPageTool(server: FastMCP): void {
@@ -19,10 +20,11 @@ export function registerGetPageTool(server: FastMCP): void {
     execute: async (params) => {
       try {
         // Validate parameters
-        const validatedParams = getPageParamSchema.parse(params);
+        const { appName, ...getPageParams } = getPageParamSchema.parse(params);
+        const resolvedAppName = resolveAppName(appName);
 
         // Execute operation using SDK
-        const page = await apiv3.getPage(validatedParams);
+        const page = await apiv3.getPage(getPageParams, { appName: resolvedAppName });
         return JSON.stringify(page);
       } catch (error) {
         // Handle validation errors

--- a/src/tools/page/getPage/schema.ts
+++ b/src/tools/page/getPage/schema.ts
@@ -1,8 +1,12 @@
 import { z } from 'zod';
+import { appNameSchema } from '../../commons/app-name-schemas';
 
 export const getPageParamSchema = z.object({
   pageId: z.string().optional().describe('ID of the GROWI page'),
   path: z.string().optional().describe('Path of the GROWI page'),
+
+  // Name used to identify the GROWI App registered with the MCP Server
+  ...appNameSchema.shape,
 });
 
 export type GetPageParam = z.infer<typeof getPageParamSchema>;

--- a/src/tools/page/getPageInfo/register.ts
+++ b/src/tools/page/getPageInfo/register.ts
@@ -2,6 +2,7 @@ import apiv3 from '@growi/sdk-typescript/v3';
 import type { FastMCP } from 'fastmcp';
 import { UserError } from 'fastmcp';
 import { z } from 'zod';
+import { resolveAppName } from '../../../commons/utils/resolve-app-name.js';
 import { getPageInfoParamSchema } from './schema.js';
 
 export function registerGetPageInfoTool(server: FastMCP): void {
@@ -19,10 +20,11 @@ export function registerGetPageInfoTool(server: FastMCP): void {
     execute: async (params) => {
       try {
         // Validate parameters
-        const validatedParams = getPageInfoParamSchema.parse(params);
+        const { appName, ...getPageInfoParams } = getPageInfoParamSchema.parse(params);
+        const resolvedAppName = resolveAppName(appName);
 
         // Execute operation using SDK
-        const result = await apiv3.getInfoForPage(validatedParams);
+        const result = await apiv3.getInfoForPage(getPageInfoParams, { appName: resolvedAppName });
 
         return JSON.stringify(result);
       } catch (error) {

--- a/src/tools/page/getPageInfo/schema.ts
+++ b/src/tools/page/getPageInfo/schema.ts
@@ -1,7 +1,11 @@
 import { z } from 'zod';
+import { appNameSchema } from '../../commons/app-name-schemas';
 
 export const getPageInfoParamSchema = z.object({
   pageId: z.string().describe('ID of the GROWI page'),
+
+  // Name used to identify the GROWI App registered with the MCP Server
+  ...appNameSchema.shape,
 });
 
 export type GetPageInfoParam = z.infer<typeof getPageInfoParamSchema>;

--- a/src/tools/page/getPageListingChildren/register.ts
+++ b/src/tools/page/getPageListingChildren/register.ts
@@ -2,6 +2,7 @@ import apiv3 from '@growi/sdk-typescript/v3';
 import type { FastMCP } from 'fastmcp';
 import { UserError } from 'fastmcp';
 import { z } from 'zod';
+import { resolveAppName } from '../../../commons/utils/resolve-app-name.js';
 import { getPageListingChildrenParamSchema } from './schema.js';
 
 export function registerGetPageListingChildrenTool(server: FastMCP): void {
@@ -19,10 +20,11 @@ export function registerGetPageListingChildrenTool(server: FastMCP): void {
     execute: async (params) => {
       try {
         // Validate parameters
-        const validatedParams = getPageListingChildrenParamSchema.parse(params);
+        const { appName, ...getChildrenParams } = getPageListingChildrenParamSchema.parse(params);
+        const resolvedAppName = resolveAppName(appName);
 
         // Execute operation using SDK
-        const result = await apiv3.getChildrenForPageListing(validatedParams);
+        const result = await apiv3.getChildrenForPageListing(getChildrenParams, { appName: resolvedAppName });
 
         return JSON.stringify(result);
       } catch (error) {

--- a/src/tools/page/getPageListingChildren/schema.ts
+++ b/src/tools/page/getPageListingChildren/schema.ts
@@ -1,8 +1,12 @@
 import { z } from 'zod';
+import { appNameSchema } from '../../commons/app-name-schemas';
 
 export const getPageListingChildrenParamSchema = z.object({
   id: z.string().optional().describe('Page ID to get children for (optional)'),
   path: z.string().optional().describe('Page path to get children for (optional)'),
+
+  // Name used to identify the GROWI App registered with the MCP Server
+  ...appNameSchema.shape,
 });
 
 export type GetPageListingChildrenParam = z.infer<typeof getPageListingChildrenParamSchema>;

--- a/src/tools/page/getPageListingRoot/register.ts
+++ b/src/tools/page/getPageListingRoot/register.ts
@@ -2,6 +2,7 @@ import apiv3 from '@growi/sdk-typescript/v3';
 import type { FastMCP } from 'fastmcp';
 import { UserError } from 'fastmcp';
 import { z } from 'zod';
+import { resolveAppName } from '../../../commons/utils/resolve-app-name.js';
 import { getPageListingRootParamSchema } from './schema.js';
 
 export function registerGetPageListingRootTool(server: FastMCP): void {
@@ -19,10 +20,11 @@ export function registerGetPageListingRootTool(server: FastMCP): void {
     execute: async (params) => {
       try {
         // Validate parameters
-        getPageListingRootParamSchema.parse(params);
+        const { appName } = getPageListingRootParamSchema.parse(params);
+        const resolvedAppName = resolveAppName(appName);
 
         // Execute operation using SDK
-        const result = await apiv3.getRootForPageListing();
+        const result = await apiv3.getRootForPageListing({ appName: resolvedAppName });
 
         return JSON.stringify(result);
       } catch (error) {

--- a/src/tools/page/getPageListingRoot/schema.ts
+++ b/src/tools/page/getPageListingRoot/schema.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod';
+import { appNameSchema } from '../../commons/app-name-schemas';
 
 // Root page listing doesn't require any parameters
-export const getPageListingRootParamSchema = z.object({});
+export const getPageListingRootParamSchema = z.object({
+  // Name used to identify the GROWI App registered with the MCP Server
+  ...appNameSchema.shape,
+});
 
 export type GetPageListingRootParam = z.infer<typeof getPageListingRootParamSchema>;

--- a/src/tools/page/getPageTag/register.ts
+++ b/src/tools/page/getPageTag/register.ts
@@ -2,6 +2,7 @@ import apiv1 from '@growi/sdk-typescript/v1';
 import type { FastMCP } from 'fastmcp';
 import { UserError } from 'fastmcp';
 import { z } from 'zod';
+import { resolveAppName } from '../../../commons/utils/resolve-app-name.js';
 import { getPageTagParamSchema } from './schema.js';
 
 export function registerGetPageTagTool(server: FastMCP): void {
@@ -19,10 +20,11 @@ export function registerGetPageTagTool(server: FastMCP): void {
     execute: async (params) => {
       try {
         // Validate parameters
-        const validatedParams = getPageTagParamSchema.parse(params);
+        const { appName, ...getPageTagParams } = getPageTagParamSchema.parse(params);
+        const resolvedAppName = resolveAppName(appName);
 
         // Execute operation using SDK
-        const result = await apiv1.getPageTag(validatedParams);
+        const result = await apiv1.getPageTag(getPageTagParams, { appName: resolvedAppName });
 
         return JSON.stringify(result);
       } catch (error) {

--- a/src/tools/page/getPageTag/schema.ts
+++ b/src/tools/page/getPageTag/schema.ts
@@ -1,7 +1,11 @@
 import { z } from 'zod';
+import { appNameSchema } from '../../commons/app-name-schemas';
 
 export const getPageTagParamSchema = z.object({
   pageId: z.string().describe('Page ID to get tags for'),
+
+  // Name used to identify the GROWI App registered with the MCP Server
+  ...appNameSchema.shape,
 });
 
 export type GetPageTagParam = z.infer<typeof getPageTagParamSchema>;

--- a/src/tools/page/getRecentPages/register.ts
+++ b/src/tools/page/getRecentPages/register.ts
@@ -2,6 +2,7 @@ import apiv3 from '@growi/sdk-typescript/v3';
 import type { FastMCP } from 'fastmcp';
 import { UserError } from 'fastmcp';
 import { z } from 'zod';
+import { resolveAppName } from '../../../commons/utils/resolve-app-name.js';
 import { getRecentPagesParamSchema } from './schema.js';
 
 export function registerGetRecentPagesTool(server: FastMCP): void {
@@ -19,10 +20,11 @@ export function registerGetRecentPagesTool(server: FastMCP): void {
     execute: async (params) => {
       try {
         // Validate parameters
-        const validatedParams = getRecentPagesParamSchema.parse(params);
+        const { appName, ...getRecentPagesParams } = getRecentPagesParamSchema.parse(params);
+        const resolvedAppName = resolveAppName(appName);
 
         // Execute operation using SDK
-        const result = await apiv3.getRecentForPages(validatedParams);
+        const result = await apiv3.getRecentForPages(getRecentPagesParams, { appName: resolvedAppName });
 
         return JSON.stringify(result);
       } catch (error) {

--- a/src/tools/page/getRecentPages/schema.ts
+++ b/src/tools/page/getRecentPages/schema.ts
@@ -1,9 +1,13 @@
 import { z } from 'zod';
+import { appNameSchema } from '../../commons/app-name-schemas';
 
 export const getRecentPagesParamSchema = z.object({
   limit: z.number().optional().describe('Number of pages to retrieve per page (optional)'),
   page: z.number().optional().describe('Page number for pagination (optional)'),
   includeWip: z.boolean().optional().describe('Whether to include work-in-progress pages (optional)'),
+
+  // Name used to identify the GROWI App registered with the MCP Server
+  ...appNameSchema.shape,
 });
 
 export type GetRecentPagesParam = z.infer<typeof getRecentPagesParamSchema>;

--- a/src/tools/page/pageListingInfo/register.ts
+++ b/src/tools/page/pageListingInfo/register.ts
@@ -2,6 +2,7 @@ import apiv3 from '@growi/sdk-typescript/v3';
 import type { FastMCP } from 'fastmcp';
 import { UserError } from 'fastmcp';
 import { z } from 'zod';
+import { resolveAppName } from '../../../commons/utils/resolve-app-name.js';
 import { pageListingInfoParamSchema } from './schema.js';
 
 export function registerPageListingInfoTool(server: FastMCP): void {
@@ -19,10 +20,11 @@ export function registerPageListingInfoTool(server: FastMCP): void {
     execute: async (params) => {
       try {
         // Validate parameters
-        const validatedParams = pageListingInfoParamSchema.parse(params);
+        const { appName, ...pageListingInfoParams } = pageListingInfoParamSchema.parse(params);
+        const resolvedAppName = resolveAppName(appName);
 
         // Execute operation using SDK
-        const result = await apiv3.getInfoForPageListing(validatedParams);
+        const result = await apiv3.getInfoForPageListing(pageListingInfoParams, { appName: resolvedAppName });
         return JSON.stringify(result);
       } catch (error) {
         // Handle validation errors

--- a/src/tools/page/pageListingInfo/schema.ts
+++ b/src/tools/page/pageListingInfo/schema.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod';
+import { appNameSchema } from '../../commons/app-name-schemas';
 
 export const pageListingInfoParamSchema = z.object({
   pageIds: z.array(z.string()).optional().describe('Array of page IDs to get summary information for (One of `pageIds` or `path` must be provided)'),
   path: z.string().optional().describe('Path of the page to get summary information for (One of `pageIds` or `path` must be provided)'),
+
+  // Name used to identify the GROWI App registered with the MCP Server
+  ...appNameSchema.shape,
 });

--- a/src/tools/page/publishPage/register.ts
+++ b/src/tools/page/publishPage/register.ts
@@ -1,5 +1,6 @@
 import apiv3 from '@growi/sdk-typescript/v3';
 import { type FastMCP, UserError } from 'fastmcp';
+import { resolveAppName } from '../../../commons/utils/resolve-app-name.js';
 import { publishPageParamSchema } from './schema';
 
 export function registerPublishPageTool(server: FastMCP): void {
@@ -16,9 +17,10 @@ export function registerPublishPageTool(server: FastMCP): void {
     },
     execute: async (params) => {
       try {
-        const validatedParams = publishPageParamSchema.parse(params);
+        const { appName, ...publishPageParams } = publishPageParamSchema.parse(params);
+        const resolvedAppName = resolveAppName(appName);
 
-        const page = await apiv3.putPublishByPageIdForPage(validatedParams.pageId);
+        const page = await apiv3.putPublishByPageIdForPage(publishPageParams.pageId, { appName: resolvedAppName });
 
         return JSON.stringify({
           status: 'success',

--- a/src/tools/page/publishPage/schema.ts
+++ b/src/tools/page/publishPage/schema.ts
@@ -1,7 +1,11 @@
 import { z } from 'zod';
+import { appNameSchema } from '../../commons/app-name-schemas';
 
 export const publishPageParamSchema = z.object({
   pageId: z.string().min(1, 'Page ID is required'),
+
+  // Name used to identify the GROWI App registered with the MCP Server
+  ...appNameSchema.shape,
 });
 
 export type PublishPageParam = z.infer<typeof publishPageParamSchema>;

--- a/src/tools/page/renamePage/register.ts
+++ b/src/tools/page/renamePage/register.ts
@@ -1,6 +1,7 @@
 import { type FastMCP, UserError } from 'fastmcp';
 import { z } from 'zod';
 import { isGrowiApiError } from '../../../commons/api/growi-api-error.js';
+import { resolveAppName } from '../../../commons/utils/resolve-app-name.js';
 import { renamePageParamSchema } from './schema.js';
 import { renamePage } from './service.js';
 
@@ -12,10 +13,11 @@ export function registerRenamePageTool(server: FastMCP): void {
     execute: async (params) => {
       try {
         // Validate parameters
-        const validatedParams = renamePageParamSchema.parse(params);
+        const { appName, ...renamePageParams } = renamePageParamSchema.parse(params);
+        const resolvedAppName = resolveAppName(appName);
 
         // Call service
-        const page = await renamePage(validatedParams);
+        const page = await renamePage(renamePageParams, resolvedAppName);
         return JSON.stringify(page);
       } catch (error) {
         // Handle Zod validation errors

--- a/src/tools/page/renamePage/schema.ts
+++ b/src/tools/page/renamePage/schema.ts
@@ -1,5 +1,6 @@
 import type { IPage } from '@growi/core/dist/interfaces';
 import { z } from 'zod';
+import { appNameSchema } from '../../commons/app-name-schemas';
 
 export const renamePageParamSchema = z.object({
   pageId: z.string().describe('ID of the page to rename'),
@@ -9,6 +10,9 @@ export const renamePageParamSchema = z.object({
   isRenameRedirect: z.boolean().optional().default(false).describe('Whether to create a redirect from the old path'),
   isRecursively: z.boolean().optional().default(false).describe('Whether to rename child pages recursively'),
   updateMetadata: z.boolean().optional().default(false).describe('Whether to update page metadata'),
+
+  // Name used to identify the GROWI App registered with the MCP Server
+  ...appNameSchema.shape,
 });
 
 export type RenamePageParam = z.infer<typeof renamePageParamSchema>;

--- a/src/tools/page/renamePage/service.ts
+++ b/src/tools/page/renamePage/service.ts
@@ -3,14 +3,17 @@ import type { PutRenameForPages200 } from '@growi/sdk-typescript/v3';
 import { GrowiApiError } from '../../../commons/api/growi-api-error.js';
 import type { RenamePageParam } from './schema.js';
 
-export async function renamePage(params: RenamePageParam): Promise<PutRenameForPages200> {
+export async function renamePage(params: RenamePageParam, appName: string): Promise<PutRenameForPages200> {
   try {
     // Check if pages exist at the new path using SDK only if both paths are provided
     if (params.path && params.newPagePath) {
-      const existPathsResult = await apiv3.getExistPathsForPage({
-        fromPath: params.path,
-        toPath: params.newPagePath,
-      });
+      const existPathsResult = await apiv3.getExistPathsForPage(
+        {
+          fromPath: params.path,
+          toPath: params.newPagePath,
+        },
+        { appName },
+      );
 
       if (existPathsResult.existPaths?.[params.newPagePath]) {
         throw new GrowiApiError('Page already exists at the target path', 409, {
@@ -20,14 +23,17 @@ export async function renamePage(params: RenamePageParam): Promise<PutRenameForP
     }
 
     // Proceed with renaming using SDK
-    const renameResult = await apiv3.putRenameForPages({
-      pageId: params.pageId,
-      revisionId: params.revisionId,
-      ...(params.newPagePath && { newPagePath: params.newPagePath }),
-      ...(params.isRenameRedirect !== undefined && { isRenameRedirect: params.isRenameRedirect }),
-      ...(params.isRecursively !== undefined && { isRecursively: params.isRecursively }),
-      ...(params.updateMetadata !== undefined && { updateMetadata: params.updateMetadata }),
-    });
+    const renameResult = await apiv3.putRenameForPages(
+      {
+        pageId: params.pageId,
+        revisionId: params.revisionId,
+        ...(params.newPagePath && { newPagePath: params.newPagePath }),
+        ...(params.isRenameRedirect !== undefined && { isRenameRedirect: params.isRenameRedirect }),
+        ...(params.isRecursively !== undefined && { isRecursively: params.isRecursively }),
+        ...(params.updateMetadata !== undefined && { updateMetadata: params.updateMetadata }),
+      },
+      { appName },
+    );
 
     if (!renameResult.page) {
       throw new GrowiApiError('Invalid response received from page rename API', 500, { response: renameResult });

--- a/src/tools/page/searchPages/register.ts
+++ b/src/tools/page/searchPages/register.ts
@@ -2,6 +2,7 @@ import apiv1 from '@growi/sdk-typescript/v1';
 import { type FastMCP, UserError } from 'fastmcp';
 import { ZodError } from 'zod';
 import { GrowiApiError, isGrowiApiError } from '../../../commons/api/growi-api-error.js';
+import { resolveAppName } from '../../../commons/utils/resolve-app-name.js';
 import { searchPagesParamSchema } from './schema.js';
 
 export function registerSearchPagesTool(server: FastMCP): void {
@@ -19,10 +20,11 @@ export function registerSearchPagesTool(server: FastMCP): void {
     execute: async (params, context) => {
       try {
         // Validate input using zod schema
-        const validatedParams = searchPagesParamSchema.parse(params);
+        const { appName, ...searchPagesParams } = searchPagesParamSchema.parse(params);
+        const resolvedAppName = resolveAppName(appName);
 
         // Execute search using SDK
-        const response = await apiv1.searchPages(validatedParams);
+        const response = await apiv1.searchPages(searchPagesParams, { appName: resolvedAppName });
 
         if (!response.data) {
           throw new GrowiApiError('Invalid response received from search API', 500, { response });

--- a/src/tools/page/searchPages/schema.ts
+++ b/src/tools/page/searchPages/schema.ts
@@ -1,5 +1,6 @@
 import type { SearchPagesParams } from '@growi/sdk-typescript/v1';
 import { z } from 'zod';
+import { appNameSchema } from '../../commons/app-name-schemas';
 
 export const searchPagesParamSchema = z.object({
   q: z
@@ -11,6 +12,9 @@ export const searchPagesParamSchema = z.object({
   path: z.string().optional(),
   offset: z.number().int().min(0).optional(),
   limit: z.number().int().min(1).optional(),
+
+  // Name used to identify the GROWI App registered with the MCP Server
+  ...appNameSchema.shape,
 }) satisfies z.ZodType<SearchPagesParams>;
 
 export type ValidatedParams = z.infer<typeof searchPagesParamSchema>;

--- a/src/tools/page/unpublishPage/register.ts
+++ b/src/tools/page/unpublishPage/register.ts
@@ -1,5 +1,6 @@
 import apiv3 from '@growi/sdk-typescript/v3';
 import { type FastMCP, UserError } from 'fastmcp';
+import { resolveAppName } from '../../../commons/utils/resolve-app-name.js';
 import { unpublishPageParamSchema } from './schema';
 
 export function registerUnpublishPageTool(server: FastMCP): void {
@@ -16,9 +17,10 @@ export function registerUnpublishPageTool(server: FastMCP): void {
     },
     execute: async (params) => {
       try {
-        const validatedParams = unpublishPageParamSchema.parse(params);
+        const { appName, ...unpublishPageParams } = unpublishPageParamSchema.parse(params);
+        const resolvedAppName = resolveAppName(appName);
 
-        const page = await apiv3.putUnpublishByPageIdForPage(validatedParams.pageId);
+        const page = await apiv3.putUnpublishByPageIdForPage(unpublishPageParams.pageId, { appName: resolvedAppName });
 
         return JSON.stringify({
           status: 'success',

--- a/src/tools/page/unpublishPage/schema.ts
+++ b/src/tools/page/unpublishPage/schema.ts
@@ -1,7 +1,11 @@
 import { z } from 'zod';
+import { appNameSchema } from '../../commons/app-name-schemas';
 
 export const unpublishPageParamSchema = z.object({
   pageId: z.string().min(1, 'Page ID is required'),
+
+  // Name used to identify the GROWI App registered with the MCP Server
+  ...appNameSchema.shape,
 });
 
 export type UnpublishPageParam = z.infer<typeof unpublishPageParamSchema>;

--- a/src/tools/page/updatePage/register.ts
+++ b/src/tools/page/updatePage/register.ts
@@ -3,6 +3,7 @@ import type { FastMCP } from 'fastmcp';
 import { UserError } from 'fastmcp';
 import { z } from 'zod';
 import { isGrowiApiError } from '../../../commons/api/growi-api-error.js';
+import { resolveAppName } from '../../../commons/utils/resolve-app-name.js';
 import { updatePageParamSchema } from './schema.js';
 
 export function registerUpdatePageTool(server: FastMCP): void {
@@ -17,10 +18,11 @@ export function registerUpdatePageTool(server: FastMCP): void {
     execute: async (params) => {
       try {
         // Validate parameters
-        const validatedParams = updatePageParamSchema.parse(params);
+        const { appName, ...updatePageParams } = updatePageParamSchema.parse(params);
+        const resolvedAppName = resolveAppName(appName);
 
         // Execute update operation using SDK
-        const result = await apiv3.putPage(validatedParams);
+        const result = await apiv3.putPage(updatePageParams, { appName: resolvedAppName });
 
         if (!result?.page) {
           throw new UserError('Failed to retrieve page data after update');

--- a/src/tools/page/updatePage/schema.ts
+++ b/src/tools/page/updatePage/schema.ts
@@ -1,5 +1,6 @@
 import type { PutPageBody } from '@growi/sdk-typescript/v3';
 import { z } from 'zod';
+import { appNameSchema } from '../../commons/app-name-schemas';
 
 export const updatePageParamSchema = z.object({
   pageId: z.string().describe('ID of the page to update'),
@@ -17,6 +18,9 @@ export const updatePageParamSchema = z.object({
     .describe('IDs of the user groups to grant access to'),
   overwriteScopesOfDescendants: z.boolean().optional().describe('Whether to overwrite grant settings of descendant pages'),
   wip: z.boolean().optional().describe('Whether the page is work in progress'),
+
+  // Name used to identify the GROWI App registered with the MCP Server
+  ...appNameSchema.shape,
 } satisfies { [K in keyof PutPageBody]: z.ZodType<PutPageBody[K]> });
 
 export type UpdatePageParam = z.infer<typeof updatePageParamSchema>;

--- a/src/tools/revision/getRevision/register.ts
+++ b/src/tools/revision/getRevision/register.ts
@@ -2,6 +2,7 @@ import apiv3 from '@growi/sdk-typescript/v3';
 import type { FastMCP } from 'fastmcp';
 import { UserError } from 'fastmcp';
 import { z } from 'zod';
+import { resolveAppName } from '../../../commons/utils/resolve-app-name.js';
 import { getRevisionParamSchema } from './schema.js';
 
 export function registerGetRevisionTool(server: FastMCP): void {
@@ -19,10 +20,11 @@ export function registerGetRevisionTool(server: FastMCP): void {
     execute: async (params) => {
       try {
         // Validate parameters
-        const validatedParams = getRevisionParamSchema.parse(params);
+        const { appName, ...getRevisionParams } = getRevisionParamSchema.parse(params);
+        const resolvedAppName = resolveAppName(appName);
 
         // Execute operation using SDK
-        const result = await apiv3.getRevisionsById(validatedParams.id, { pageId: validatedParams.pageId });
+        const result = await apiv3.getRevisionsById(getRevisionParams.id, { pageId: getRevisionParams.pageId }, { appName: resolvedAppName });
 
         return JSON.stringify(result);
       } catch (error) {

--- a/src/tools/revision/getRevision/schema.ts
+++ b/src/tools/revision/getRevision/schema.ts
@@ -1,8 +1,12 @@
 import { z } from 'zod';
+import { appNameSchema } from '../../commons/app-name-schemas';
 
 export const getRevisionParamSchema = z.object({
   id: z.string().describe('Revision ID to get details for'),
   pageId: z.string().describe('Page ID that the revision belongs to'),
+
+  // Name used to identify the GROWI App registered with the MCP Server
+  ...appNameSchema.shape,
 });
 
 export type GetRevisionParam = z.infer<typeof getRevisionParamSchema>;

--- a/src/tools/revision/listRevisions/register.ts
+++ b/src/tools/revision/listRevisions/register.ts
@@ -3,6 +3,7 @@ import type { FastMCP } from 'fastmcp';
 import { UserError } from 'fastmcp';
 import { z } from 'zod';
 import { isGrowiApiError } from '../../../commons/api/growi-api-error.js';
+import { resolveAppName } from '../../../commons/utils/resolve-app-name.js';
 import { listRevisionsParamSchema } from './schema.js';
 
 export function registerListRevisionsTool(server: FastMCP): void {
@@ -20,10 +21,11 @@ export function registerListRevisionsTool(server: FastMCP): void {
     execute: async (params) => {
       try {
         // Validate parameters
-        const validatedParams = listRevisionsParamSchema.parse(params);
+        const { appName, ...listRevisionsParams } = listRevisionsParamSchema.parse(params);
+        const resolvedAppName = resolveAppName(appName);
 
         // Execute operation using SDK
-        const result = await apiv3.getListForRevisions(validatedParams);
+        const result = await apiv3.getListForRevisions(listRevisionsParams, { appName: resolvedAppName });
 
         return JSON.stringify(result);
       } catch (error) {

--- a/src/tools/revision/listRevisions/schema.ts
+++ b/src/tools/revision/listRevisions/schema.ts
@@ -1,9 +1,13 @@
 import { z } from 'zod';
+import { appNameSchema } from '../../commons/app-name-schemas';
 
 export const listRevisionsParamSchema = z.object({
   pageId: z.string().describe('Page ID to get revisions for'),
   limit: z.number().optional().describe('Number of revisions to retrieve per page (optional)'),
   offset: z.number().optional().describe('Offset for pagination (optional)'),
+
+  // Name used to identify the GROWI App registered with the MCP Server
+  ...appNameSchema.shape,
 });
 
 export type ListRevisionsParam = z.infer<typeof listRevisionsParamSchema>;

--- a/src/tools/shareLinks/createShareLink/register.ts
+++ b/src/tools/shareLinks/createShareLink/register.ts
@@ -2,6 +2,7 @@ import apiv3 from '@growi/sdk-typescript/v3';
 import type { FastMCP } from 'fastmcp';
 import { UserError } from 'fastmcp';
 import { z } from 'zod';
+import { resolveAppName } from '../../../commons/utils/resolve-app-name.js';
 import { createShareLinkParamSchema } from './schema.js';
 
 export function registerCreateShareLinkTool(server: FastMCP): void {
@@ -19,10 +20,11 @@ export function registerCreateShareLinkTool(server: FastMCP): void {
     execute: async (params) => {
       try {
         // Validate parameters
-        const validatedParams = createShareLinkParamSchema.parse(params);
+        const { appName, ...createShareLinkParams } = createShareLinkParamSchema.parse(params);
+        const resolvedAppName = resolveAppName(appName);
 
         // Execute operation using SDK
-        const result = await apiv3.postShareLinks(validatedParams);
+        const result = await apiv3.postShareLinks(createShareLinkParams, { appName: resolvedAppName });
 
         return JSON.stringify(result);
       } catch (error) {

--- a/src/tools/shareLinks/createShareLink/schema.ts
+++ b/src/tools/shareLinks/createShareLink/schema.ts
@@ -1,9 +1,13 @@
 import { z } from 'zod';
+import { appNameSchema } from '../../commons/app-name-schemas';
 
 export const createShareLinkParamSchema = z.object({
   relatedPage: z.string().describe('Page ID to create share link for'),
   description: z.string().optional().describe('Description for the share link'),
   expiredAt: z.string().optional().describe('Expiration date for the share link (ISO string)'),
+
+  // Name used to identify the GROWI App registered with the MCP Server
+  ...appNameSchema.shape,
 });
 
 export type CreateShareLinkParam = z.infer<typeof createShareLinkParamSchema>;

--- a/src/tools/shareLinks/deleteShareLinkById/register.ts
+++ b/src/tools/shareLinks/deleteShareLinkById/register.ts
@@ -2,6 +2,7 @@ import apiv3 from '@growi/sdk-typescript/v3';
 import type { FastMCP } from 'fastmcp';
 import { UserError } from 'fastmcp';
 import { z } from 'zod';
+import { resolveAppName } from '../../../commons/utils/resolve-app-name.js';
 import { deleteShareLinkByIdParamSchema } from './schema.js';
 
 export function registerDeleteShareLinkByIdTool(server: FastMCP): void {
@@ -19,10 +20,11 @@ export function registerDeleteShareLinkByIdTool(server: FastMCP): void {
     execute: async (params) => {
       try {
         // Validate parameters
-        const validatedParams = deleteShareLinkByIdParamSchema.parse(params);
+        const { appName, ...deleteShareLinkByIdParams } = deleteShareLinkByIdParamSchema.parse(params);
+        const resolvedAppName = resolveAppName(appName);
 
         // Execute operation using SDK
-        const result = await apiv3.deleteShareLinksById(validatedParams.id);
+        const result = await apiv3.deleteShareLinksById(deleteShareLinkByIdParams.id, { appName: resolvedAppName });
 
         return JSON.stringify(result);
       } catch (error) {

--- a/src/tools/shareLinks/deleteShareLinkById/schema.ts
+++ b/src/tools/shareLinks/deleteShareLinkById/schema.ts
@@ -1,7 +1,11 @@
 import { z } from 'zod';
+import { appNameSchema } from '../../commons/app-name-schemas';
 
 export const deleteShareLinkByIdParamSchema = z.object({
   id: z.string().describe('Share link ID to delete'),
+
+  // Name used to identify the GROWI App registered with the MCP Server
+  ...appNameSchema.shape,
 });
 
 export type DeleteShareLinkByIdParam = z.infer<typeof deleteShareLinkByIdParamSchema>;

--- a/src/tools/shareLinks/deleteShareLinks/register.ts
+++ b/src/tools/shareLinks/deleteShareLinks/register.ts
@@ -2,6 +2,7 @@ import apiv3 from '@growi/sdk-typescript/v3';
 import type { FastMCP } from 'fastmcp';
 import { UserError } from 'fastmcp';
 import { z } from 'zod';
+import { resolveAppName } from '../../../commons/utils/resolve-app-name.js';
 import { deleteShareLinksParamSchema } from './schema.js';
 
 export function registerDeleteShareLinksTool(server: FastMCP): void {
@@ -19,10 +20,11 @@ export function registerDeleteShareLinksTool(server: FastMCP): void {
     execute: async (params) => {
       try {
         // Validate parameters
-        const validatedParams = deleteShareLinksParamSchema.parse(params);
+        const { appName, ...deleteShareLinksParams } = deleteShareLinksParamSchema.parse(params);
+        const resolvedAppName = resolveAppName(appName);
 
         // Execute operation using SDK
-        const result = await apiv3.deleteShareLinks(validatedParams);
+        const result = await apiv3.deleteShareLinks(deleteShareLinksParams, { appName: resolvedAppName });
 
         return JSON.stringify(result);
       } catch (error) {

--- a/src/tools/shareLinks/deleteShareLinks/schema.ts
+++ b/src/tools/shareLinks/deleteShareLinks/schema.ts
@@ -1,7 +1,11 @@
 import { z } from 'zod';
+import { appNameSchema } from '../../commons/app-name-schemas';
 
 export const deleteShareLinksParamSchema = z.object({
   relatedPage: z.string().describe('Page ID to delete all share links for'),
+
+  // Name used to identify the GROWI App registered with the MCP Server
+  ...appNameSchema.shape,
 });
 
 export type DeleteShareLinksParam = z.infer<typeof deleteShareLinksParamSchema>;

--- a/src/tools/shareLinks/getShareLinks/register.ts
+++ b/src/tools/shareLinks/getShareLinks/register.ts
@@ -2,6 +2,7 @@ import apiv3 from '@growi/sdk-typescript/v3';
 import type { FastMCP } from 'fastmcp';
 import { UserError } from 'fastmcp';
 import { z } from 'zod';
+import { resolveAppName } from '../../../commons/utils/resolve-app-name.js';
 import { getShareLinksParamSchema } from './schema.js';
 
 export function registerGetShareLinksTool(server: FastMCP): void {
@@ -19,10 +20,11 @@ export function registerGetShareLinksTool(server: FastMCP): void {
     execute: async (params) => {
       try {
         // Validate parameters
-        const validatedParams = getShareLinksParamSchema.parse(params);
+        const { appName, ...getShareLinksParams } = getShareLinksParamSchema.parse(params);
+        const resolvedAppName = resolveAppName(appName);
 
         // Execute operation using SDK
-        const result = await apiv3.getShareLinks(validatedParams);
+        const result = await apiv3.getShareLinks(getShareLinksParams, { appName: resolvedAppName });
 
         return JSON.stringify(result);
       } catch (error) {

--- a/src/tools/shareLinks/getShareLinks/schema.ts
+++ b/src/tools/shareLinks/getShareLinks/schema.ts
@@ -1,7 +1,11 @@
 import { z } from 'zod';
+import { appNameSchema } from '../../commons/app-name-schemas';
 
 export const getShareLinksParamSchema = z.object({
   relatedPage: z.string().describe('Page ID to get share links for'),
+
+  // Name used to identify the GROWI App registered with the MCP Server
+  ...appNameSchema.shape,
 });
 
 export type GetShareLinksParam = z.infer<typeof getShareLinksParamSchema>;

--- a/src/tools/tag/getTagList/register.ts
+++ b/src/tools/tag/getTagList/register.ts
@@ -2,6 +2,7 @@ import apiv1 from '@growi/sdk-typescript/v1';
 import type { FastMCP } from 'fastmcp';
 import { UserError } from 'fastmcp';
 import { z } from 'zod';
+import { resolveAppName } from '../../../commons/utils/resolve-app-name.js';
 import { getTagListParamSchema } from './schema.js';
 
 export function registerGetTagListTool(server: FastMCP): void {
@@ -19,10 +20,11 @@ export function registerGetTagListTool(server: FastMCP): void {
     execute: async (params) => {
       try {
         // Validate parameters
-        const validatedParams = getTagListParamSchema.parse(params);
+        const { appName, ...getTagListParams } = getTagListParamSchema.parse(params);
+        const resolvedAppName = resolveAppName(appName);
 
         // Execute operation using SDK
-        const result = await apiv1.listTags(validatedParams);
+        const result = await apiv1.listTags(getTagListParams, { appName: resolvedAppName });
 
         return JSON.stringify(result);
       } catch (error) {

--- a/src/tools/tag/getTagList/schema.ts
+++ b/src/tools/tag/getTagList/schema.ts
@@ -1,8 +1,12 @@
 import { z } from 'zod';
+import { appNameSchema } from '../../commons/app-name-schemas';
 
 export const getTagListParamSchema = z.object({
   limit: z.number().optional().describe('Number of tags to retrieve per page (optional)'),
   offset: z.number().optional().describe('Offset for pagination (optional)'),
+
+  // Name used to identify the GROWI App registered with the MCP Server
+  ...appNameSchema.shape,
 });
 
 export type GetTagListParam = z.infer<typeof getTagListParamSchema>;

--- a/src/tools/tag/searchTags/register.ts
+++ b/src/tools/tag/searchTags/register.ts
@@ -2,6 +2,7 @@ import apiv1 from '@growi/sdk-typescript/v1';
 import type { FastMCP } from 'fastmcp';
 import { UserError } from 'fastmcp';
 import { z } from 'zod';
+import { resolveAppName } from '../../../commons/utils/resolve-app-name.js';
 import { searchTagsParamSchema } from './schema.js';
 
 export function registerSearchTagsTool(server: FastMCP): void {
@@ -19,13 +20,14 @@ export function registerSearchTagsTool(server: FastMCP): void {
     execute: async (params) => {
       try {
         // Validate parameters
-        const validatedParams = searchTagsParamSchema.parse(params);
+        const { appName, ...searchTagsParams } = searchTagsParamSchema.parse(params);
+        const resolvedAppName = resolveAppName(appName);
 
         // Prepare API parameters
-        const apiParams = validatedParams.q ? { q: validatedParams.q } : undefined;
+        const apiParams = searchTagsParams.q ? { q: searchTagsParams.q } : undefined;
 
         // Execute operation using SDK
-        const result = await apiv1.searchTags(apiParams);
+        const result = await apiv1.searchTags(apiParams, { appName: resolvedAppName });
 
         return JSON.stringify(result);
       } catch (error) {

--- a/src/tools/tag/searchTags/schema.ts
+++ b/src/tools/tag/searchTags/schema.ts
@@ -1,7 +1,11 @@
 import { z } from 'zod';
+import { appNameSchema } from '../../commons/app-name-schemas';
 
 export const searchTagsParamSchema = z.object({
-  q: z.string().optional().describe('Search query for tags (optional)'),
+  q: z.string().describe('Query string to search tags'),
+
+  // Name used to identify the GROWI App registered with the MCP Server
+  ...appNameSchema.shape,
 });
 
 export type SearchTagsParam = z.infer<typeof searchTagsParamSchema>;

--- a/src/tools/tag/updateTag/register.ts
+++ b/src/tools/tag/updateTag/register.ts
@@ -2,6 +2,7 @@ import apiv1 from '@growi/sdk-typescript/v1';
 import type { FastMCP } from 'fastmcp';
 import { UserError } from 'fastmcp';
 import { z } from 'zod';
+import { resolveAppName } from '../../../commons/utils/resolve-app-name.js';
 import { updateTagParamSchema } from './schema.js';
 
 export function registerUpdateTagTool(server: FastMCP): void {
@@ -19,10 +20,11 @@ export function registerUpdateTagTool(server: FastMCP): void {
     execute: async (params) => {
       try {
         // Validate parameters
-        const validatedParams = updateTagParamSchema.parse(params);
+        const { appName, ...updateTagParams } = updateTagParamSchema.parse(params);
+        const resolvedAppName = resolveAppName(appName);
 
         // Execute operation using SDK
-        const result = await apiv1.updateTag(validatedParams);
+        const result = await apiv1.updateTag(updateTagParams, { appName: resolvedAppName });
 
         return JSON.stringify(result);
       } catch (error) {

--- a/src/tools/tag/updateTag/schema.ts
+++ b/src/tools/tag/updateTag/schema.ts
@@ -1,7 +1,11 @@
 import { z } from 'zod';
+import { appNameSchema } from '../../commons/app-name-schemas';
 
 export const updateTagParamSchema = z.object({
   pageId: z.string().describe('Page ID to update tags for'),
   revisionId: z.string().describe('Revision ID of the page'),
   tags: z.array(z.string()).describe('Array of tag names to set for the page'),
+
+  // Name used to identify the GROWI App registered with the MCP Server
+  ...appNameSchema.shape,
 });

--- a/src/tools/user/getUserRecentPages/register.ts
+++ b/src/tools/user/getUserRecentPages/register.ts
@@ -2,6 +2,7 @@ import apiv3 from '@growi/sdk-typescript/v3';
 import type { FastMCP } from 'fastmcp';
 import { UserError } from 'fastmcp';
 import { z } from 'zod';
+import { resolveAppName } from '../../../commons/utils/resolve-app-name.js';
 import { getUserRecentPagesParamSchema } from './schema.js';
 
 export function registerGetUserRecentPagesTool(server: FastMCP): void {
@@ -19,10 +20,11 @@ export function registerGetUserRecentPagesTool(server: FastMCP): void {
     execute: async (params) => {
       try {
         // Validate parameters
-        const validatedParams = getUserRecentPagesParamSchema.parse(params);
+        const { appName, ...getUserRecentPagesParams } = getUserRecentPagesParamSchema.parse(params);
+        const resolvedAppName = resolveAppName(appName);
 
         // Execute operation using SDK
-        const result = await apiv3.getRecentByIdForUsers(validatedParams.id);
+        const result = await apiv3.getRecentByIdForUsers(getUserRecentPagesParams.userId, { appName: resolvedAppName });
 
         return JSON.stringify(result);
       } catch (error) {

--- a/src/tools/user/getUserRecentPages/schema.ts
+++ b/src/tools/user/getUserRecentPages/schema.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
+import { appNameSchema } from '../../commons/app-name-schemas';
 
 export const getUserRecentPagesParamSchema = z.object({
-  id: z.string().describe('User ID to get recent pages for'),
+  userId: z.string().describe('User ID to get recent pages for'),
+  limit: z.number().optional().describe('Number of pages to retrieve per page (optional)'),
+  offset: z.number().optional().describe('Offset for pagination (optional)'),
+
+  // Name used to identify the GROWI App registered with the MCP Server
+  ...appNameSchema.shape,
 });
 
 export type GetUserRecentPagesParam = z.infer<typeof getUserRecentPagesParamSchema>;


### PR DESCRIPTION
## Task
- [#171321](https://redmine.weseek.co.jp/issues/171321) [AI][MCP server] 1つの MCP サーバーから複数の wiki を操作できる
  - [#171609](https://redmine.weseek.co.jp/issues/171609) 登録済みの複数 App に対して操作できるようにする (createPageTool を参考にする)