### PR TITLE
Add suggestPath MCP tool for Smart Save

### DIFF
--- a/src/tools/aiTools/index.ts
+++ b/src/tools/aiTools/index.ts
@@ -1,0 +1,6 @@
+import type { FastMCP } from 'fastmcp';
+import { registerSuggestPathTool } from './suggestPath/index.js';
+
+export function loadAiToolsTools(server: FastMCP): void {
+  registerSuggestPathTool(server);
+}

--- a/src/tools/aiTools/suggestPath/index.ts
+++ b/src/tools/aiTools/suggestPath/index.ts
@@ -1,0 +1,1 @@
+export * from './register.js';

--- a/src/tools/aiTools/suggestPath/register.ts
+++ b/src/tools/aiTools/suggestPath/register.ts
@@ -1,0 +1,53 @@
+import { type FastMCP, UserError } from 'fastmcp';
+import { ZodError } from 'zod';
+import { GrowiApiError, isGrowiApiError } from '../../../commons/api/growi-api-error.js';
+import { resolveAppName } from '../../../commons/utils/resolve-app-name.js';
+import { suggestPathParamSchema } from './schema.js';
+import { suggestPath } from './service.js';
+
+export function registerSuggestPathTool(server: FastMCP): void {
+  server.addTool({
+    name: 'suggestPath',
+    description: 'Get suggested save paths for content in GROWI. Analyzes the content body and returns directory path candidates with grant (permission) constraints.',
+    parameters: suggestPathParamSchema,
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+      title: 'Suggest Save Path',
+    },
+    execute: async (params) => {
+      try {
+        const validatedParams = suggestPathParamSchema.parse(params);
+        const { appName, ...suggestPathParams } = validatedParams;
+
+        const resolvedAppName = resolveAppName(appName);
+        const response = await suggestPath(suggestPathParams, resolvedAppName);
+
+        try {
+          return JSON.stringify(response);
+        } catch (jsonError) {
+          throw new GrowiApiError('Failed to serialize API response', 500, { error: jsonError instanceof Error ? jsonError.message : String(jsonError) });
+        }
+      } catch (error) {
+        if (error instanceof ZodError) {
+          throw new UserError('Invalid parameters provided', {
+            validationErrors: error.errors,
+          });
+        }
+
+        if (isGrowiApiError(error)) {
+          throw new UserError(error.message, {
+            statusCode: error.statusCode,
+            details: error.details,
+          });
+        }
+
+        throw new UserError('The suggest path operation could not be completed. Please try again later.', {
+          originalError: error instanceof Error ? error.message : String(error),
+        });
+      }
+    },
+  });
+}

--- a/src/tools/aiTools/suggestPath/schema.ts
+++ b/src/tools/aiTools/suggestPath/schema.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+import { appNameSchema } from '../../commons/app-name-schemas';
+
+export const suggestPathParamSchema = z.object({
+  body: z.string().describe('The content body to analyze for path suggestions (GROWI AI will extract keywords from this)'),
+
+  // Name used to identify the GROWI App registered with the MCP Server
+  ...appNameSchema.shape,
+});
+
+export type ValidatedParams = z.infer<typeof suggestPathParamSchema>;

--- a/src/tools/aiTools/suggestPath/service.ts
+++ b/src/tools/aiTools/suggestPath/service.ts
@@ -1,0 +1,47 @@
+import { axiosInstanceManager } from '@growi/sdk-typescript';
+import { GrowiApiError } from '../../../commons/api/growi-api-error.js';
+
+export type SuggestPathParam = {
+  body: string;
+};
+
+export type PathSuggestion = {
+  type: string;
+  path: string;
+  label: string;
+  description: string;
+  grant: number;
+};
+
+export type SuggestPathResponse = {
+  suggestions: PathSuggestion[];
+};
+
+export const suggestPath = async (params: SuggestPathParam, appName: string): Promise<SuggestPathResponse> => {
+  try {
+    const instance = axiosInstanceManager.getAxiosInstance(appName);
+    const baseURL = instance.defaults.baseURL ?? '';
+
+    const response = await instance.post<SuggestPathResponse>(
+      `${baseURL}/_api/v3/ai-tools/suggest-path`,
+      { body: params.body },
+    );
+
+    if (!response.data?.suggestions) {
+      throw new GrowiApiError('Invalid response received from suggest-path API', 500, { response: response.data });
+    }
+
+    return response.data;
+  } catch (error) {
+    if (error instanceof GrowiApiError) {
+      throw error;
+    }
+
+    const message = error instanceof Error ? error.message : String(error);
+    const statusCode = error instanceof Error && 'response' in error
+      ? (error as { response?: { status?: number } }).response?.status || 500
+      : 500;
+
+    throw new GrowiApiError(`Failed to get path suggestions: ${message}`, statusCode, { originalError: error });
+  }
+};

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,4 +1,5 @@
 import type { FastMCP } from 'fastmcp';
+import { loadAiToolsTools } from './aiTools';
 import { loadCommentsTools } from './comments';
 import { loadPageTools } from './page';
 import { loadRevisionTools } from './revision';
@@ -18,4 +19,5 @@ export async function loadTools(server: FastMCP): Promise<void> {
   loadTagTools(server);
   loadShareLinksTools(server);
   loadCommentsTools(server);
+  loadAiToolsTools(server);
 }


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/179425

## Summary
- GROWI の `POST /_api/v3/ai-tools/suggest-path` エンドポイントを MCP ツール `suggestPath` として公開
- コンテンツ本文を受け取り、GROWI AI が保存先ディレクトリ候補を返す Smart Save 機能の MCP 側実装
- 既存ツールと同じパターン（schema / service / register）で実装

## Test plan
- [x] 既存テスト全通過（23/23）
- [x] Claude Desktop → UTCP → MCP → GROWI の接続確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)