### PR TITLE
fix(suggestPath): avoid double slash when base URL has trailing slash

### DIFF
--- a/src/tools/aiTools/suggestPath/service.ts
+++ b/src/tools/aiTools/suggestPath/service.ts
@@ -20,12 +20,8 @@ export type SuggestPathResponse = {
 export const suggestPath = async (params: SuggestPathParam, appName: string): Promise<SuggestPathResponse> => {
   try {
     const instance = axiosInstanceManager.getAxiosInstance(appName);
-    const baseURL = instance.defaults.baseURL ?? '';
 
-    const response = await instance.post<SuggestPathResponse>(
-      `${baseURL}/_api/v3/ai-tools/suggest-path`,
-      { body: params.body },
-    );
+    const response = await instance.post<SuggestPathResponse>('/_api/v3/ai-tools/suggest-path', { body: params.body });
 
     if (!response.data?.suggestions) {
       throw new GrowiApiError('Invalid response received from suggest-path API', 500, { response: response.data });


### PR DESCRIPTION
## Task
https://redmine.weseek.co.jp/issues/183357

## Summary
- Fix the issue where `suggestPath` constructs a malformed URL with a double slash when `GROWI_BASE_URL` is configured with a trailing slash, resulting in a 404 response.
- Pass a relative path to the axios instance so its built-in `baseURL` handling normalizes the request URL.

## Root Cause
The previous implementation manually extracted `instance.defaults.baseURL` and concatenated it with a string template. When `baseURL` ends with `/`, this produced `//_api/...`, which Express did not match and returned 404.

## Changes
- `src/tools/aiTools/suggestPath/service.ts`: Pass `'/_api/v3/ai-tools/suggest-path'` as a relative path to `instance.post()`, letting axios normalize the URL.

## Test Plan
- [x] `dev` environment (no trailing slash) — `suggestPath` returns 200 with suggestions (regression check)
- [x] Local GROWI (trailing slash) — request reaches the endpoint instead of 404 (now returns a different status, confirming the URL is correctly built and the double-slash bug is resolved)

Fixes #23