### PR TITLE
feat(skills): add growi-mcp-setup skill for guided MCP/UTCP setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,63 +22,22 @@ A Model Context Protocol (MCP) server that connects AI models to GROWI wiki cont
 - [GROWI API](https://docs.growi.org/en/api/)
 
 
-## MCP Server Configuration
-
-Supports simultaneous connections to multiple GROWI apps. Each app is configured using numbered environment variables.
-
-### Single App Configuration Example
-```json
-{
-  "mcpServers": {
-    "growi": {
-      "command": "npx",
-      "args": ["@growi/mcp-server"],
-      "env": {
-        "GROWI_APP_NAME_1": "main",
-        "GROWI_BASE_URL_1": "https://your-growi-instance.com",
-        "GROWI_API_TOKEN_1": "your_growi_api_token"
-      }
-    }
-  }
-}
-```
-
-### Multiple Apps Configuration Example
-```json
-{
-  "mcpServers": {
-    "growi": {
-      "command": "npx",
-      "args": ["@growi/mcp-server"],
-      "env": {
-        "GROWI_DEFAULT_APP_NAME": "staging",
-
-        "GROWI_APP_NAME_1": "production",
-        "GROWI_BASE_URL_1": "https://wiki.example.com",
-        "GROWI_API_TOKEN_1": "token_for_production",
-
-        "GROWI_APP_NAME_2": "staging",
-        "GROWI_BASE_URL_2": "https://wiki-staging.example.com",
-        "GROWI_API_TOKEN_2": "token_for_staging",
-        
-        "GROWI_APP_NAME_3": "development",
-        "GROWI_BASE_URL_3": "https://wiki-dev.example.com",
-        "GROWI_API_TOKEN_3": "token_for_development"
-      }
-    }
-  }
-}
-```
-
 ## Agent Skills
 
 This repository also provides [Agent Skills](https://skills.sh/) — reusable workflow definitions that AI coding agents can load to interact with GROWI more effectively.
 
 ### Available Skills
 
+- **growi-mcp-setup** — Walks you through setting up the GROWI MCP server. After the skill is installed, it guides you from configuring UTCP Code-Mode through verifying the connection.
 - **growi-smart-save** — Save content to GROWI with intelligent path suggestions. The agent calls the `suggest-path` tool, presents destination candidates, and guides the user through page naming and visibility settings.
 
-### Installing Skills
+## Quick Start (Recommended)
+
+The fastest way to start using GROWI. Once you install the skill, the rest of the setup (connecting the MCP server, configuring UTCP Code-Mode, verifying connectivity) is guided by the AI agent.
+
+### 1. Install the Skill
+
+Install the skill for your agent.
 
 #### Claude Desktop (Cowork)
 
@@ -138,6 +97,70 @@ Download skills directly from the repository and place them in your agent's skil
    - Claude Code: `.claude/skills/<skill-name>/SKILL.md`
    - Gemini CLI: `.gemini/skills/<skill-name>/SKILL.md`
    - Other agents: `.agents/skills/<skill-name>/SKILL.md`
+
+### 2. Restart Your Agent
+
+After installation, restart (or reload) your agent so the skill is recognized.
+
+### 3. Ask the AI to Set Up
+
+Tell your agent "set up GROWI", and the `growi-mcp-setup` skill will start and guide you from the MCP server connection settings through verifying connectivity.
+
+> [!NOTE]
+> If you want to configure the MCP server directly without the skill, see [Use the MCP Server Directly](#use-the-mcp-server-directly).
+
+## Use the MCP Server Directly
+
+You can also register the MCP server directly with your agent instead of using the skill. Use this for a minimal setup, or as a fallback when skill-based setup is not available.
+
+Supports simultaneous connections to multiple GROWI apps. Each app is configured using numbered environment variables.
+
+### Single App Configuration Example
+```json
+{
+  "mcpServers": {
+    "growi": {
+      "command": "npx",
+      "args": ["@growi/mcp-server"],
+      "env": {
+        "GROWI_APP_NAME_1": "main",
+        "GROWI_BASE_URL_1": "https://your-growi-instance.com",
+        "GROWI_API_TOKEN_1": "your_growi_api_token"
+      }
+    }
+  }
+}
+```
+
+### Multiple Apps Configuration Example
+```json
+{
+  "mcpServers": {
+    "growi": {
+      "command": "npx",
+      "args": ["@growi/mcp-server"],
+      "env": {
+        "GROWI_DEFAULT_APP_NAME": "staging",
+
+        "GROWI_APP_NAME_1": "production",
+        "GROWI_BASE_URL_1": "https://wiki.example.com",
+        "GROWI_API_TOKEN_1": "token_for_production",
+
+        "GROWI_APP_NAME_2": "staging",
+        "GROWI_BASE_URL_2": "https://wiki-staging.example.com",
+        "GROWI_API_TOKEN_2": "token_for_staging",
+
+        "GROWI_APP_NAME_3": "development",
+        "GROWI_BASE_URL_3": "https://wiki-dev.example.com",
+        "GROWI_API_TOKEN_3": "token_for_development"
+      }
+    }
+  }
+}
+```
+
+> [!TIP]
+> For skill-based setup (recommended), see [Quick Start](#quick-start-recommended).
 
 
 ## Available Tools (Features)

--- a/README_JP.md
+++ b/README_JP.md
@@ -22,63 +22,22 @@ GROWI wiki コンテンツにAIモデルを接続するModel Context Protocol (M
 ｰ [GROWI API](https://docs.growi.org/en/api/)
 
 
-## MCPサーバーの設定
-
-複数のGROWIアプリへの同時接続をサポートしています。各アプリには番号付きの環境変数で設定を行います。
-
-### 単一アプリの設定例
-```json
-{
-  "mcpServers": {
-    "growi": {
-      "command": "npx",
-      "args": ["@growi/mcp-server"],
-      "env": {
-        "GROWI_APP_NAME_1": "main",
-        "GROWI_BASE_URL_1": "https://your-growi-instance.com",
-        "GROWI_API_TOKEN_1": "your_growi_api_token"
-      }
-    }
-  }
-}
-```
-
-### 複数アプリの設定例
-```json
-{
-  "mcpServers": {
-    "growi": {
-      "command": "npx",
-      "args": ["@growi/mcp-server"],
-      "env": {
-        "GROWI_DEFAULT_APP_NAME": "staging",
-
-        "GROWI_APP_NAME_1": "production",
-        "GROWI_BASE_URL_1": "https://wiki.example.com",
-        "GROWI_API_TOKEN_1": "token_for_production",
-
-        "GROWI_APP_NAME_2": "staging",
-        "GROWI_BASE_URL_2": "https://wiki-staging.example.com",
-        "GROWI_API_TOKEN_2": "token_for_staging",
-        
-        "GROWI_APP_NAME_3": "development",
-        "GROWI_BASE_URL_3": "https://wiki-dev.example.com",
-        "GROWI_API_TOKEN_3": "token_for_development"
-      }
-    }
-  }
-}
-```
-
 ## エージェントスキル
 
 このリポジトリは [Agent Skills](https://skills.sh/) も提供しています。AI コーディングエージェントが GROWI とより効率的にやりとりするための再利用可能なワークフロー定義です。
 
 ### 利用可能なスキル
 
+- **growi-mcp-setup** — GROWI MCP サーバーのセットアップを伴走します。スキルのインストール後、UTCP Code-Mode の設定から接続確認までをガイドします。
 - **growi-smart-save** — コンテンツをGROWIにインテリジェントなパス提案付きで保存します。エージェントが `suggest-path` ツールを呼び出し、保存先の候補を提示し、ページ名と公開範囲の設定をガイドします。
 
-### スキルのインストール
+## クイックスタート（推奨）
+
+最短で GROWI を使い始める手順です。スキルをインストールすれば、その後のセットアップ（MCP サーバーの接続、UTCP Code-Mode の設定、疎通確認）は AI エージェントが伴走します。
+
+### 1. スキルをインストール
+
+お使いのエージェントに合わせてスキルをインストールします。
 
 #### Claude Desktop (Cowork)
 
@@ -138,6 +97,70 @@ npx skills update
    - Claude Code: `.claude/skills/<skill-name>/SKILL.md`
    - Gemini CLI: `.gemini/skills/<skill-name>/SKILL.md`
    - その他のエージェント: `.agents/skills/<skill-name>/SKILL.md`
+
+### 2. エージェントを再起動
+
+インストール後、エージェントを再起動（またはリロード）して、スキルが認識されるようにします。
+
+### 3. AI にセットアップを頼む
+
+エージェントに「GROWI をセットアップして」と伝えると、`growi-mcp-setup` スキルが起動し、MCP サーバーの接続設定から疎通確認まで案内します。
+
+> [!NOTE]
+> スキルを使わず MCP サーバーを直接設定したい場合は、[MCPサーバーを直接使う](#mcpサーバーを直接使う) を参照してください。
+
+## MCPサーバーを直接使う
+
+スキルを使わず、MCP サーバーをエージェントに直接登録することもできます。最小構成で試したいときや、スキル経由のセットアップが使えないときのフォールバックとして利用してください。
+
+複数のGROWIアプリへの同時接続をサポートしています。各アプリには番号付きの環境変数で設定を行います。
+
+### 単一アプリの設定例
+```json
+{
+  "mcpServers": {
+    "growi": {
+      "command": "npx",
+      "args": ["@growi/mcp-server"],
+      "env": {
+        "GROWI_APP_NAME_1": "main",
+        "GROWI_BASE_URL_1": "https://your-growi-instance.com",
+        "GROWI_API_TOKEN_1": "your_growi_api_token"
+      }
+    }
+  }
+}
+```
+
+### 複数アプリの設定例
+```json
+{
+  "mcpServers": {
+    "growi": {
+      "command": "npx",
+      "args": ["@growi/mcp-server"],
+      "env": {
+        "GROWI_DEFAULT_APP_NAME": "staging",
+
+        "GROWI_APP_NAME_1": "production",
+        "GROWI_BASE_URL_1": "https://wiki.example.com",
+        "GROWI_API_TOKEN_1": "token_for_production",
+
+        "GROWI_APP_NAME_2": "staging",
+        "GROWI_BASE_URL_2": "https://wiki-staging.example.com",
+        "GROWI_API_TOKEN_2": "token_for_staging",
+
+        "GROWI_APP_NAME_3": "development",
+        "GROWI_BASE_URL_3": "https://wiki-dev.example.com",
+        "GROWI_API_TOKEN_3": "token_for_development"
+      }
+    }
+  }
+}
+```
+
+> [!TIP]
+> スキル経由のセットアップ（推奨）は [クイックスタート](#クイックスタート推奨) を参照してください。
 
 
 ## 利用可能なツール（機能）

--- a/skills/growi-mcp-setup/SKILL.md
+++ b/skills/growi-mcp-setup/SKILL.md
@@ -16,7 +16,7 @@ What this skill does **not** cover: installing the plugin/skill itself (adding t
 
 ## Why UTCP Code-Mode
 
-The GROWI MCP server exposes ~20 tools. Loading every tool schema into the client context is heavy on tokens. UTCP Code-Mode sits between the client and the GROWI MCP server and lets the agent call tools through a single code-execution interface, which keeps context small.
+The GROWI MCP server exposes nearly 30 tools (27 as of this writing). Loading every tool schema into the client context is heavy on tokens. UTCP Code-Mode sits between the client and the GROWI MCP server and lets the agent call tools through a single code-execution interface, which keeps context small.
 
 UTCP Code-Mode is the **default path** this skill sets up — do not assume it is already present; the workflow below installs and wires it. A direct MCP connection also works (all tools function) and is offered only as a fallback or for light use — see the last section.
 

--- a/skills/growi-mcp-setup/SKILL.md
+++ b/skills/growi-mcp-setup/SKILL.md
@@ -6,19 +6,19 @@ description: |
 
 # GROWI MCP Setup: Connection Bootstrap Workflow
 
-Guide the user from "the skill is installed" to "GROWI tools actually work", by setting up UTCP Code-Mode and verifying the connection.
+Guide the user from "the skill is installed" to "GROWI tools actually work" — setting up **UTCP Code-Mode from scratch**, wiring in the GROWI MCP server, and verifying the connection. This is the shortest supported path: the user should not need to configure UTCP by hand beforehand; this skill walks them through it.
 
 ## Scope
 
-This skill covers the gap **after** the user has installed the GROWI plugin/skill (and restarted their agent) and **before** GROWI tools are usable.
+This skill takes over **once it is loaded** (i.e. the GROWI plugin/skill is already installed) and drives everything up to "GROWI tools work" — including UTCP Code-Mode setup, which earlier docs assumed was done in advance.
 
-Installation itself (adding the marketplace, installing the plugin, restarting the agent) is the user's responsibility — it cannot be automated, because the agent cannot act until the skill is recognized. Assume the user has already done that when this skill runs.
+What this skill does **not** cover: installing the plugin/skill itself (adding the marketplace, installing, restarting the agent). That step cannot be automated — the agent cannot act until the skill is recognized — so it lives in the GROWI documentation, not here. See the install instructions in the GROWI docs **"AI ツール（スキル）を使う" / "AI Tools (Skills)"** page (`/guide/features/ai-tools`). Assume the user has finished that when this skill runs.
 
 ## Why UTCP Code-Mode
 
 The GROWI MCP server exposes ~20 tools. Loading every tool schema into the client context is heavy on tokens. UTCP Code-Mode sits between the client and the GROWI MCP server and lets the agent call tools through a single code-execution interface, which keeps context small.
 
-The recommended path is **UTCP Code-Mode**. A direct MCP connection also works (all tools function), but is only suggested as a fallback or for light use — see the last section.
+UTCP Code-Mode is the **default path** this skill sets up — do not assume it is already present; the workflow below installs and wires it. A direct MCP connection also works (all tools function) and is offered only as a fallback or for light use — see the last section.
 
 ## Workflow
 
@@ -30,9 +30,15 @@ Ask the user for:
 - **API token** — issued from GROWI: User Settings → API Token
 - **App name** — a short identifier the user picks (e.g. `main`)
 
-### Step 2: Check / install UTCP Code-Mode
+### Step 2: Prepare UTCP Code-Mode
 
-UTCP Code-Mode runs via `npx`, so no separate install is required. It is registered as an MCP server in the client config.
+Assume UTCP Code-Mode is **not yet set up** — this skill installs it now. There is no global install step: UTCP Code-Mode runs on demand via `npx @utcp/code-mode-mcp`, fetched the first time the client launches it. What you set up is the wiring — registering it as an MCP server (Step 3) and giving it a config file (Step 4).
+
+Confirm the prerequisite the on-demand `npx` launch depends on:
+
+- **Node.js 18+** and network access (so `npx` can fetch `@utcp/code-mode-mcp` and `@growi/mcp-server` on first run). Check with `node --version`.
+
+If a `code-mode` MCP server is *already* registered in the client config, you do not need to add it again — reuse it and only ensure its `UTCP_CONFIG_FILE` includes GROWI (Step 4).
 
 ### Step 3: Register UTCP Code-Mode in the client config
 
@@ -97,6 +103,8 @@ Create `.utcp_config.json` at the path referenced by `UTCP_CONFIG_FILE`, registe
 
 - `${VAR}` references an environment variable — prefer this over writing the token inline.
 - The values collected in Step 1 fill `GROWI_APP_NAME_1` / `GROWI_BASE_URL_1` / `GROWI_API_TOKEN_1`.
+- The `_1` suffix groups one app's settings. **All three (`GROWI_APP_NAME_n`, `GROWI_BASE_URL_n`, `GROWI_API_TOKEN_n`) must be present for that app to be recognized** — if any one is missing, the GROWI MCP server fails to start with `Invalid environment variables` ("At least one GROWI app configuration is required"). To connect multiple GROWI instances, repeat the trio with `_2`, `_3`, etc.
+- `GROWI_BASE_URL_n` must be a full, valid URL (e.g. `https://wiki.example.com`), not just a hostname.
 
 ### Step 5: Restart the agent and verify
 
@@ -104,7 +112,7 @@ Create `.utcp_config.json` at the path referenced by `UTCP_CONFIG_FILE`, registe
 2. After restart, confirm that GROWI tools are visible (e.g. `suggestPath`, `searchPages`).
 3. Run a lightweight read-only call (such as listing recent pages) to confirm the connection works end to end.
 
-If tools are visible and a call succeeds, setup is complete — the user can now use workflows like `growi-smart-save`.
+If tools are visible and a call succeeds, setup is complete — the user can now use workflows like `growi-smart-save`. For feature-level usage (what the tools can do, Smart Save, etc.), point them back to the GROWI docs "AI ツール（スキル）を使う" / "AI Tools (Skills)" page.
 
 ## Fallback: connecting MCP directly (without UTCP)
 
@@ -131,5 +139,6 @@ All GROWI tools work this way, but every tool schema stays resident in the clien
 ## Troubleshooting
 
 - **Tools still not visible after restart** — re-check the `UTCP_CONFIG_FILE` path is absolute and the JSON is valid.
+- **`Invalid environment variables` / "At least one GROWI app configuration is required"** — a `GROWI_*_n` trio is incomplete. Each app needs all three of `GROWI_APP_NAME_n`, `GROWI_BASE_URL_n`, `GROWI_API_TOKEN_n` set together (see Step 4).
 - **Auth errors on a call** — verify the API token and Base URL; confirm the token has not been revoked in GROWI.
 - **`npx` cannot find the package** — ensure Node.js 18+ is installed and the machine has network access.

--- a/skills/growi-mcp-setup/SKILL.md
+++ b/skills/growi-mcp-setup/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: growi-mcp-setup
+description: |
+  Set up and connect the GROWI MCP server so GROWI tools become available to the agent. Use this skill when the user asks to "set up GROWI", "connect GROWI", "configure the GROWI MCP server", or when GROWI tools (such as suggestPath, searchPages, createPage) are expected but not available. Also use this right after the user has installed the GROWI plugin/skill and needs to finish wiring up the connection.
+---
+
+# GROWI MCP Setup: Connection Bootstrap Workflow
+
+Guide the user from "the skill is installed" to "GROWI tools actually work", by setting up UTCP Code-Mode and verifying the connection.
+
+## Scope
+
+This skill covers the gap **after** the user has installed the GROWI plugin/skill (and restarted their agent) and **before** GROWI tools are usable.
+
+Installation itself (adding the marketplace, installing the plugin, restarting the agent) is the user's responsibility — it cannot be automated, because the agent cannot act until the skill is recognized. Assume the user has already done that when this skill runs.
+
+## Why UTCP Code-Mode
+
+The GROWI MCP server exposes ~20 tools. Loading every tool schema into the client context is heavy on tokens. UTCP Code-Mode sits between the client and the GROWI MCP server and lets the agent call tools through a single code-execution interface, which keeps context small.
+
+The recommended path is **UTCP Code-Mode**. A direct MCP connection also works (all tools function), but is only suggested as a fallback or for light use — see the last section.
+
+## Workflow
+
+### Step 1: Collect GROWI connection info
+
+Ask the user for:
+
+- **Base URL** of their GROWI instance (e.g. `https://wiki.example.com`)
+- **API token** — issued from GROWI: User Settings → API Token
+- **App name** — a short identifier the user picks (e.g. `main`)
+
+### Step 2: Check / install UTCP Code-Mode
+
+UTCP Code-Mode runs via `npx`, so no separate install is required. It is registered as an MCP server in the client config.
+
+### Step 3: Register UTCP Code-Mode in the client config
+
+Register a `code-mode` MCP server in the client's MCP config. How to do this depends on the client.
+
+**Claude Code** — edit the config file, or use the `claude mcp add` CLI:
+
+- User / Local scope: `~/.claude.json`
+- Project scope: `.mcp.json` at the project root (supports `${VAR}` expansion)
+
+`claude mcp add` can register stdio servers; run `claude mcp add --help` to check the exact flags for scope and for passing an env var like `UTCP_CONFIG_FILE`.
+
+**Claude Desktop** — open Settings → Developer → "Edit Config", or edit the file directly, then restart Claude Desktop:
+
+- macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+
+**Other agents** — edit their respective MCP config file.
+
+The `mcpServers` entry to add (when editing the config manually):
+
+```json
+{
+  "mcpServers": {
+    "code-mode": {
+      "command": "npx",
+      "args": ["@utcp/code-mode-mcp"],
+      "env": {
+        "UTCP_CONFIG_FILE": "/absolute/path/to/.utcp_config.json"
+      }
+    }
+  }
+}
+```
+
+### Step 4: Create .utcp_config.json
+
+Create `.utcp_config.json` at the path referenced by `UTCP_CONFIG_FILE`, registering the GROWI MCP server as a tool source:
+
+```json
+{
+  "manual_call_templates": [
+    {
+      "call_template_type": "mcp",
+      "config": {
+        "mcpServers": {
+          "growi": {
+            "command": "npx",
+            "args": ["@growi/mcp-server"],
+            "env": {
+              "GROWI_APP_NAME_1": "main",
+              "GROWI_BASE_URL_1": "${GROWI_BASE_URL_1}",
+              "GROWI_API_TOKEN_1": "${GROWI_API_TOKEN_1}"
+            }
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
+- `${VAR}` references an environment variable — prefer this over writing the token inline.
+- The values collected in Step 1 fill `GROWI_APP_NAME_1` / `GROWI_BASE_URL_1` / `GROWI_API_TOKEN_1`.
+
+### Step 5: Restart the agent and verify
+
+1. Tell the user to restart / reload their agent so the new MCP config is picked up.
+2. After restart, confirm that GROWI tools are visible (e.g. `suggestPath`, `searchPages`).
+3. Run a lightweight read-only call (such as listing recent pages) to confirm the connection works end to end.
+
+If tools are visible and a call succeeds, setup is complete — the user can now use workflows like `growi-smart-save`.
+
+## Fallback: connecting MCP directly (without UTCP)
+
+If UTCP Code-Mode cannot be used, register the GROWI MCP server directly in the client's MCP config:
+
+```json
+{
+  "mcpServers": {
+    "growi": {
+      "command": "npx",
+      "args": ["@growi/mcp-server"],
+      "env": {
+        "GROWI_APP_NAME_1": "main",
+        "GROWI_BASE_URL_1": "https://your-growi-instance.com",
+        "GROWI_API_TOKEN_1": "your_growi_api_token"
+      }
+    }
+  }
+}
+```
+
+All GROWI tools work this way, but every tool schema stays resident in the client context. This is fine for light use; for regular use, prefer the UTCP path above.
+
+## Troubleshooting
+
+- **Tools still not visible after restart** — re-check the `UTCP_CONFIG_FILE` path is absolute and the JSON is valid.
+- **Auth errors on a call** — verify the API token and Base URL; confirm the token has not been revoked in GROWI.
+- **`npx` cannot find the package** — ensure Node.js 18+ is installed and the machine has network access.

--- a/skills/growi-mcp-setup/SKILL.md
+++ b/skills/growi-mcp-setup/SKILL.md
@@ -44,10 +44,11 @@ If a `code-mode` MCP server is *already* registered in the client config, you do
 
 Register a `code-mode` MCP server in the client's MCP config. How to do this depends on the client.
 
-**Claude Code** — edit the config file, or use the `claude mcp add` CLI:
+**Claude Code** — edit the config file, or use the `claude mcp add` CLI. There are three scopes:
 
-- User / Local scope: `~/.claude.json`
-- Project scope: `.mcp.json` at the project root (supports `${VAR}` expansion)
+- `local` (per-project, private) — stored in `~/.claude.json` under `projects[<cwd>].mcpServers`
+- `user` (global, all projects) — stored in `~/.claude.json` under the top-level `mcpServers`
+- `project` (shared via VCS) — stored in `.mcp.json` at the project root (supports `${VAR}` expansion)
 
 `claude mcp add` can register stdio servers; run `claude mcp add --help` to check the exact flags for scope and for passing an env var like `UTCP_CONFIG_FILE`.
 

--- a/skills/growi-mcp-setup/SKILL.md
+++ b/skills/growi-mcp-setup/SKILL.md
@@ -126,13 +126,16 @@ If UTCP Code-Mode cannot be used, register the GROWI MCP server directly in the 
       "args": ["@growi/mcp-server"],
       "env": {
         "GROWI_APP_NAME_1": "main",
-        "GROWI_BASE_URL_1": "https://your-growi-instance.com",
-        "GROWI_API_TOKEN_1": "your_growi_api_token"
+        "GROWI_BASE_URL_1": "${GROWI_BASE_URL_1}",
+        "GROWI_API_TOKEN_1": "${GROWI_API_TOKEN_1}"
       }
     }
   }
 }
 ```
+
+> [!WARNING]
+> Do not write the API token inline in this file. Use `${GROWI_API_TOKEN_1}` to read it from an environment variable, the same as in Step 4. Configs are easy to share or commit by accident.
 
 All GROWI tools work this way, but every tool schema stays resident in the client context. This is fine for light use; for regular use, prefer the UTCP path above.
 


### PR DESCRIPTION
## Task

- スキル更新: https://redmine.weseek.co.jp/issues/182780

## Summary

Adds the `growi-mcp-setup` skill, which walks a user from "the skill is installed" to "GROWI tools actually work" — setting up UTCP Code-Mode from scratch, wiring in the GROWI MCP server, and verifying the connection. Also leads the README with a quickstart.

The skill treats **UTCP Code-Mode as the default path it sets up itself**, rather than assuming UTCP is already configured. Direct MCP connection remains available as a fallback. Plugin/skill installation itself is out of scope (it cannot be automated before the skill is recognized) and is delegated to the GROWI docs, with a cross-link.

## Changes

- Add `skills/growi-mcp-setup/SKILL.md` — guided setup workflow
- Lead `README.md` / `README_JP.md` with a quickstart
- Document the env trio requirement: all three of `GROWI_APP_NAME_n` / `GROWI_BASE_URL_n` / the matching API token var must be set together, or the server fails with `Invalid environment variables`

## Testing

Verified end-to-end against a local GROWI instance:

- code-mode connects via `claude mcp add` (client-managed `npx`, confirmed on Windows)
- GROWI MCP server exposes all 27 tools through UTCP Code-Mode
- read (`getRecentPages`) and write (`createPage`) calls succeed

Note: Claude Desktop / macOS verification is tracked separately (#183162).

## Out of scope

- Documentation restructure of the GROWI docs (mcp-server / ai-tools pages) — tracked in #183264

🤖 Generated with [Claude Code](https://claude.com/claude-code)

