### PR TITLE
feat(comments): add addComment and removeComment tools

### DIFF
--- a/src/tools/comments/addComment/index.ts
+++ b/src/tools/comments/addComment/index.ts
@@ -1,0 +1,1 @@
+export { registerAddCommentTool } from './register';

--- a/src/tools/comments/addComment/register.ts
+++ b/src/tools/comments/addComment/register.ts
@@ -1,0 +1,50 @@
+import apiv1 from '@growi/sdk-typescript/v1';
+import type { FastMCP } from 'fastmcp';
+import { UserError } from 'fastmcp';
+import { z } from 'zod';
+import { resolveAppName } from '../../../commons/utils/resolve-app-name.js';
+import { addCommentParamSchema } from './schema.js';
+
+export function registerAddCommentTool(server: FastMCP): void {
+  server.addTool({
+    name: 'addComment',
+    description: 'Add a comment to a page in GROWI',
+    parameters: addCommentParamSchema,
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+      title: 'Add Comment',
+    },
+    execute: async (params) => {
+      try {
+        const { appName, ...addCommentParams } = addCommentParamSchema.parse(params);
+        const resolvedAppName = resolveAppName(appName);
+
+        const result = await apiv1.addComment(
+          {
+            commentForm: {
+              page_id: addCommentParams.pageId,
+              ...(addCommentParams.revisionId && { revision_id: addCommentParams.revisionId }),
+              comment: addCommentParams.comment,
+            },
+          },
+          { appName: resolvedAppName },
+        );
+
+        return JSON.stringify(result);
+      } catch (error) {
+        if (error instanceof z.ZodError) {
+          throw new UserError('Invalid parameters provided', {
+            validationErrors: error.errors,
+          });
+        }
+
+        throw new UserError('Failed to add comment', {
+          originalError: error instanceof Error ? error.message : String(error),
+        });
+      }
+    },
+  });
+}

--- a/src/tools/comments/addComment/schema.ts
+++ b/src/tools/comments/addComment/schema.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+import { appNameSchema } from '../../commons/app-name-schemas';
+
+export const addCommentParamSchema = z.object({
+  pageId: z.string().describe('ID of the page to add a comment to'),
+  revisionId: z.string().optional().describe('ID of the revision to attach the comment to (optional)'),
+  comment: z.string().min(1).describe('Comment body text'),
+
+  // Name used to identify the GROWI App registered with the MCP Server
+  ...appNameSchema.shape,
+});
+
+export type AddCommentParam = z.infer<typeof addCommentParamSchema>;

--- a/src/tools/comments/index.ts
+++ b/src/tools/comments/index.ts
@@ -1,6 +1,10 @@
 import type { FastMCP } from 'fastmcp';
+import { registerAddCommentTool } from './addComment';
 import { registerGetCommentsTool } from './getComments';
+import { registerRemoveCommentTool } from './removeComment';
 
 export async function loadCommentsTools(server: FastMCP): Promise<void> {
   registerGetCommentsTool(server);
+  registerAddCommentTool(server);
+  registerRemoveCommentTool(server);
 }

--- a/src/tools/comments/removeComment/index.ts
+++ b/src/tools/comments/removeComment/index.ts
@@ -1,0 +1,1 @@
+export { registerRemoveCommentTool } from './register';

--- a/src/tools/comments/removeComment/register.ts
+++ b/src/tools/comments/removeComment/register.ts
@@ -1,0 +1,41 @@
+import apiv1 from '@growi/sdk-typescript/v1';
+import type { FastMCP } from 'fastmcp';
+import { UserError } from 'fastmcp';
+import { z } from 'zod';
+import { resolveAppName } from '../../../commons/utils/resolve-app-name.js';
+import { removeCommentParamSchema } from './schema.js';
+
+export function registerRemoveCommentTool(server: FastMCP): void {
+  server.addTool({
+    name: 'removeComment',
+    description: 'Remove a comment from a page in GROWI',
+    parameters: removeCommentParamSchema,
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+      title: 'Remove Comment',
+    },
+    execute: async (params) => {
+      try {
+        const { appName, ...removeCommentParams } = removeCommentParamSchema.parse(params);
+        const resolvedAppName = resolveAppName(appName);
+
+        const result = await apiv1.removeComment({ comment_id: removeCommentParams.commentId }, { appName: resolvedAppName });
+
+        return JSON.stringify(result);
+      } catch (error) {
+        if (error instanceof z.ZodError) {
+          throw new UserError('Invalid parameters provided', {
+            validationErrors: error.errors,
+          });
+        }
+
+        throw new UserError('Failed to remove comment', {
+          originalError: error instanceof Error ? error.message : String(error),
+        });
+      }
+    },
+  });
+}

--- a/src/tools/comments/removeComment/schema.ts
+++ b/src/tools/comments/removeComment/schema.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+import { appNameSchema } from '../../commons/app-name-schemas';
+
+export const removeCommentParamSchema = z.object({
+  commentId: z.string().describe('ID of the comment to remove'),
+
+  // Name used to identify the GROWI App registered with the MCP Server
+  ...appNameSchema.shape,
+});
+
+export type RemoveCommentParam = z.infer<typeof removeCommentParamSchema>;


### PR DESCRIPTION
## Summary

Add two new tools to the `comments` category:

- **`addComment`** — Post a new comment to a GROWI page
- **`removeComment`** — Delete an existing comment from a GROWI page

These complement the existing `getComments` tool, enabling full create/delete workflows for comments via MCP.

## Changes

- `src/tools/comments/addComment/` — schema, register, index
- `src/tools/comments/removeComment/` — schema, register, index
- `src/tools/comments/index.ts` — register new tools

Both tools use the same v1 API as the existing `getComments` tool (`apiv1.addComment` / `apiv1.removeComment`).

## Note on `updateComment`

I initially implemented `updateComment` as well, but the v1 `/comments.update` endpoint does not exist in GROWI v7.5.1, and the v3 `PATCH /api/v3/comments/:id` endpoint requires a CSRF token which is not available via API token auth. Leaving this for a future PR once v3 support is clearer.

## Testing

Tested on GROWI v7.5.1:

| Tool | Result |
|------|--------|
| `addComment` | ✅ Works |
| `getComments` (existing) | ✅ Comment appears in list |
| `removeComment` | ✅ Works |