### PR TITLE
feat(growi-smart-save): add Vault local-grep path discovery mode

### DIFF
--- a/skills/growi-smart-save/SKILL.md
+++ b/skills/growi-smart-save/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: growi-smart-save
 description: |
-  Save content to GROWI wiki with intelligent path suggestions. Use this skill when the user asks to save, store, or archive content to GROWI. Triggers on: "save to GROWI", "store this in the wiki", "save this page", or any request to persist content in GROWI. Also use when the user uploads a document and wants it stored in GROWI, or after a conversation session the user wants to capture as a wiki page.
+  Save content to GROWI wiki with intelligent path suggestions. Use this skill when the user asks to save, store, or archive content to GROWI. Triggers on: "save to GROWI", "store this in the wiki", "save this page", or any request to persist content in GROWI. Also use when the user uploads a document and wants it stored in GROWI, or after a conversation session the user wants to capture as a wiki page. Finding the destination uses a local GROWI Vault clone (grep-based discovery) when one is reachable, and falls back to the server-side suggest-path tool otherwise — either way the user ends up choosing and saving.
 ---
 
 # Smart Save: GROWI Content Save Workflow
@@ -12,16 +12,46 @@ Save content to GROWI by finding the best destination, confirming with the user,
 
 ### Step 1: Get destination candidates
 
-Call the **suggest-path** tool with the content body the user wants to save.
+Produce a small set of candidate destination directories for the document. There are two ways to
+get them; **prefer the first when it is available**, because discovering the home yourself from
+the wiki's real content finds the right shelf more reliably than the server's indexed search.
+
+**Step 1a — Vault local-grep discovery (preferred).** If a GROWI Vault clone is reachable, find
+the candidates by grepping the local clone of the wiki yourself. This is the better path: you are
+a stronger reasoner than the server's path agent, and a real `grep` over raw Markdown hits the
+exact tokens (slugs, dates, IDs) that decide the right shelf. To do it:
+
+1. Check whether Vault is usable and get/refresh a clone — see
+   `references/vault-clone-access.md` (detect, `git clone`/`fetch` via the user's GROWI token,
+   where to cache it). If Vault is not usable for any reason, fall through to Step 1b.
+2. Discover candidate shelves by grepping the clone — see `references/vault-grep-discovery.md`
+   (the method: grep the document's concrete tokens, follow where hits cluster, confirm by
+   reading sibling pages, converge on 1–3 parent directories). Judge content fit, not
+   path-string similarity.
+
+The output is 1–3 candidate directory paths (each ending in `/`), the same shape Step 1b would
+return. Carry them into Step 2.
+
+**Step 1b — Server suggest-path (fallback).** If no Vault clone is reachable (Vault disabled,
+not bootstrapped, no local `git`, or any clone/fetch failure), call the **suggest-path** tool
+instead.
 
 - **Input**: The full content body (the text to be saved)
-- **Output**: An array of destination suggestions
+- **Output**: An array of destination suggestions (see "Understanding the server response" below)
+
+Whichever path produced the candidates, the rest of the workflow is identical.
 
 ### Step 2: Present options to the user
 
-Show all suggestions from the response. Always add a **"specify path manually"** option — this is your responsibility, not part of the API response.
+Show the candidate destinations from Step 1. Always add a **"specify path manually"** option —
+this is your responsibility, not part of any tool response.
 
-For each suggestion, show the `label` and `description` to help the user decide. Example presentation:
+- **From Step 1b (server)**, each candidate has a `label` and `description` — show them as-is.
+- **From Step 1a (Vault grep)**, you found the candidates yourself, so write a one-line reason for
+  each (why this shelf fits — the sibling pages that confirm it), playing the role `description`
+  plays for server results. Lead with the shelf you judged best.
+
+Example presentation:
 
 ```
 1. Save as memo — Save to your personal memo area
@@ -33,22 +63,32 @@ For each suggestion, show the `label` and `description` to help the user decide.
 
 After the user selects a destination:
 
-1. Propose a page name based on the content
+1. Propose a page name based on the content. **If Step 1a discovery showed a naming convention at
+   the chosen shelf, follow it** — when the sibling pages use a fixed label (e.g. every feature
+   folder's spec is named `仕様-Specification-`) or a consistent pattern, match it rather than
+   inventing a content-derived title. The destination's existing names are the strongest hint for
+   what this page should be called.
 2. Let the user confirm or modify
 3. Combine directory path + page name into the final path
    - Example: `/Tech Notes/React/` + `Jotai vs Redux` → `/Tech Notes/React/Jotai vs Redux`
 
-The `path` from suggestions is always a directory (ends with `/`). You are responsible for proposing the page name portion.
+The destination is always a directory (ends with `/`). You are responsible for proposing the page
+name portion. (When the destination came from Step 1a, make sure the directory is the **decoded**
+GROWI page path, not the on-disk percent-encoded filename — see `references/vault-grep-discovery.md`.)
 
 ### Step 4: Confirm visibility (grant)
 
-Before saving, confirm the page's visibility with the user. Present up to 3 simple options based on the destination's grant upper limit:
+Before saving, confirm the page's visibility with the user. The `grant` value at a directory is an
+**upper limit** — a constraint, not a recommendation — and the user must never be allowed to pick a
+visibility that exceeds it. How you know the limit depends on which Step 1 path produced the
+candidate:
 
-1. **Inherit from parent page** — use the `grant` value from the API response as-is
+**When the candidate came from Step 1b (server).** The suggestion carries a `grant` upper limit.
+Present up to 3 options based on it:
+
+1. **Inherit from parent page** — use the destination's `grant` value as-is
 2. **Only me** — grant 4 (Only-me)
 3. **Anyone with the link** — grant 2 (Anyone-with-the-link)
-
-**Which options to show depends on the grant upper limit:**
 
 | Grant upper limit | Options to show |
 |-------------------|-----------------|
@@ -56,10 +96,6 @@ Before saving, confirm the page's visibility with the user. Present up to 3 simp
 | 2 (Anyone-with-link) | All three: Inherit from parent / Only me / Anyone with the link |
 | 5 (Group-only)    | Two only: Inherit from parent / Only me (omit "Anyone with the link" — it would exceed the upper limit) |
 | 4 (Only-me)       | No confirmation needed — Only-me is the only option |
-
-The user must never select a grant that exceeds the upper limit from the API.
-
-Example (when grant upper limit is 1):
 
 ```
 How should the page visibility be set?
@@ -70,17 +106,28 @@ How should the page visibility be set?
 
 Do NOT silently default to the upper limit. Always ask unless the only option is Only-me.
 
+**When the candidate came from Step 1a (Vault grep).** You discovered the path from the clone, so
+you do **not** have the grant upper limit in hand. Default to **inheriting from the parent** —
+save with `grant` omitted, and GROWI applies the parent's visibility, which by construction cannot
+exceed the limit. Only ask the user about visibility if they signal they want something more
+restrictive (e.g. "only me"); if so, pass that grant — GROWI rejects it server-side if it would
+exceed the limit, and you can relay that back rather than guessing the limit yourself. (If you do
+want the precise limit, resolve the destination with `getPage` → `getPageInfo`, but inheriting is
+the simpler default and is usually what the user wants.)
+
 ### Step 5: Save the page
 
 Use the **page creation** tool to save:
 
 - **path**: The combined path from Step 3
 - **body**: The content to save
-- **grant**: The visibility level confirmed in Step 4
+- **grant**: The visibility confirmed in Step 4 — or **omit it to inherit from the parent**, which
+  is the default for Vault-grep candidates (Step 1a) and whenever the user is happy with parent
+  visibility
 
-## Understanding the response
+## Understanding the server response (Step 1b)
 
-Each suggestion contains:
+When candidates come from the suggest-path tool, each suggestion contains:
 
 | Field         | Description                                              |
 |---------------|----------------------------------------------------------|
@@ -89,6 +136,9 @@ Each suggestion contains:
 | `label`       | Short display label for the option                       |
 | `description` | Why this destination is recommended — show this to the user |
 | `grant`       | Maximum permission level allowed at this path            |
+
+Vault-grep candidates (Step 1a) are just directory `path`s you discovered; you supply the
+reason-to-show yourself (Step 2) and inherit grant by default (Step 4).
 
 ## Grant constraints
 
@@ -105,6 +155,12 @@ When saving, the selected grant must not exceed this limit. See Step 4 for how t
 
 ## Fallback behavior
 
-- Suggestions contain only `memo` type → present those + manual input option
-- suggest-path tool fails or is unavailable → offer manual path input
-- Always ensure the user can save their content regardless of tool availability
+The discovery method degrades gracefully — the user can always save, whatever is available:
+
+- **Vault clone not reachable** (disabled, not bootstrapped, no local `git`, clone/fetch error)
+  → fall back to the server suggest-path tool (Step 1b). This is silent and expected, not an
+  error to surface.
+- **suggest-path tool also fails or is unavailable** → offer manual path input.
+- **Candidates are all `memo` type, or none fit the document** → present what you have plus the
+  manual input option; don't force a poor pick.
+- Always ensure the user can save their content regardless of which discovery path worked.

--- a/skills/growi-smart-save/references/vault-clone-access.md
+++ b/skills/growi-smart-save/references/vault-clone-access.md
@@ -1,0 +1,78 @@
+# Getting a Vault clone (detect, clone, refresh)
+
+The grep discovery in `vault-grep-discovery.md` needs the wiki as local Markdown files. GROWI
+exposes the Vault as a **PAT-authenticated git endpoint**, so obtaining and refreshing the clone
+is plain `git` — no special tooling. This file is the mechanical how-to; the judgement of *where
+a document belongs* lives in `vault-grep-discovery.md`.
+
+## Is a Vault clone usable? (the branch condition)
+
+Use Vault local-grep discovery when **all** of these hold; otherwise fall back to the server
+suggest-path tool. Falling back is always safe — it is the original behavior.
+
+1. **You can reach the GROWI instance and its API token.** These are the same base URL and token
+   the GROWI MCP server is configured with (`GROWI_BASE_URL_n` / `GROWI_API_TOKEN_n` — see the
+   `growi-mcp-setup` skill). If multiple GROWI instances are connected, the target is the one
+   this save is for; if it is ambiguous, ask the user which instance.
+2. **Vault is enabled and bootstrapped on that instance.** The git endpoint returns an error
+   page or refuses if Vault is off or its initial bootstrap has not finished. Treat any failure
+   to clone/fetch as "not usable" and fall back — do not block the save.
+3. **You can run `git` locally.** The client environment must have `git` and a writable working
+   directory. If not, fall back.
+
+If any check fails, say nothing dramatic — just use the server suggest-path tool (Step 1b of the
+main workflow). The user still gets candidates.
+
+## The git endpoint
+
+GROWI serves the Vault as a **read-only git smart-http endpoint** at `<base-url>/vault.git`:
+
+- `git clone` / `git fetch` work normally (`info/refs` + `git-upload-pack`).
+- Pushing is rejected (`git-receive-pack` → 403) — the clone is read-only, which is exactly what
+  discovery needs.
+- **Authentication is the user's GROWI API token (PAT)**, sent as a Bearer header.
+- **Namespaces are filtered by the token's permissions automatically** — the server only delivers
+  the wiki areas that token may read. You do not compute or filter permissions yourself; clone
+  with the user's own token and you get exactly the pages they may see.
+
+## Clone (first time)
+
+Pick a stable local cache path the skill owns, namespaced per instance so multiple GROWI
+instances don't collide — e.g. `<cache-root>/growi-vault/<instance-id>/`. The user does not need
+to manage this path. GROWI does not dictate where the clone lives; that is the client's choice.
+
+```bash
+git -c http.extraHeader="Authorization: Bearer <PAT>" \
+  clone --filter=blob:none <base-url>/vault.git <cache-root>/growi-vault/<instance-id>
+```
+
+- `--filter=blob:none` makes it a **partial clone** — file contents are fetched lazily, so the
+  initial clone stays small even on a large wiki. `grep`/`read` still work; blobs download on
+  first access. (Recommended by the GROWI Vault docs.)
+- A few pages with names longer than the filesystem limit may fail to check out
+  (`File name too long`); the clone still succeeds and all normal pages are present. Ignore that
+  warning.
+- If you only need shared pages and want to skip personal `user/` space, you can additionally use
+  sparse-checkout — but the default full checkout is fine for discovery.
+
+## Refresh (keep it current)
+
+The clone is a snapshot as of the last fetch. **Before using it for discovery, refresh it** so
+you are not grepping a stale wiki:
+
+```bash
+cd <cache-root>/growi-vault/<instance-id>
+git -c http.extraHeader="Authorization: Bearer <PAT>" fetch --quiet
+git reset --hard origin/HEAD --quiet
+```
+
+A fetch is cheap and resolves the freshness concern that a one-time clone would have. If the
+fetch fails (network, Vault disabled since last time), fall back to the server suggest-path tool
+rather than grepping a stale or missing clone.
+
+## Security notes
+
+- The PAT is the user's existing GROWI API token — do not print it, log it, or write it into the
+  clone. Pass it only via the `http.extraHeader` argument at call time.
+- The clone contains real wiki content the user can read. Keep it in the skill's cache path, not
+  somewhere it would be shared or committed.

--- a/skills/growi-smart-save/references/vault-grep-discovery.md
+++ b/skills/growi-smart-save/references/vault-grep-discovery.md
@@ -1,0 +1,129 @@
+# Vault local-grep path discovery
+
+This is the **preferred** way to find save-path candidates when a GROWI Vault clone is
+available. Instead of asking the server's suggest-path tool (a smaller model that searches
+Elasticsearch indirectly), **you** — the client model — search a local git clone of the wiki
+directly with `grep`/`ls`/`read`. You are a stronger reasoner than the server agent, and a real
+`grep` over raw Markdown hits exact tokens (slugs, dates, IDs) that an indexed search only
+approximates. That combination is why local discovery finds the right shelf more reliably.
+
+Keep one thing front of mind throughout: **you are placing a NEW document.** It does not yet
+exist in the wiki, so you will not find a copy of it. You find its home through **sibling
+pages** of the same topic and kind.
+
+## What a Vault clone looks like
+
+A GROWI Vault clone is the whole wiki as Markdown files on disk:
+
+- A page `/A/B/C` is the file `A/B/C.md`.
+- If that page also has children, they live in the directory `A/B/C/`.
+- So a page that groups children appears **twice**: as `<name>.md` (its own body) and as
+  `<name>/` (the directory of its children).
+- A **box/grouping page** (a directory page that exists only to hold children) often has a body
+  that is just `$lsx()` or is empty. Its own body tells you little — read its children to learn
+  what it groups. (An empty/`$lsx()` body can make `head` exit non-zero with no output — that
+  means "box page, empty body", **not** "page doesn't exist". Don't misread it.)
+- **Filenames are URL-encoded for path-unsafe characters.** A page-path segment containing
+  characters like `:` is stored on disk percent-encoded (e.g. the page `旧: …` becomes the file
+  `旧%3A ….md`). When you turn a discovered **file path** back into a GROWI **page path** for the
+  rest of the workflow (Step 3), **decode** those (`%3A`→`:`, etc.) so the final path is the real
+  page path, not the on-disk filename.
+
+This makes every lookup a plain filesystem operation:
+
+| What you need | Command |
+|---------------|---------|
+| List a shelf's contents | `ls "<clone>/<dir>/"` |
+| Read a page's own body | read `<clone>/<dir>/<name>.md` |
+| Find pages by **content** (the key move) | `grep -rl "<token>" --include="*.md" "<clone>"` |
+| Is this a box page? | its `.md` body is empty / `$lsx()`-only |
+
+## The discovery method — grep like a careful human
+
+The goal is to land on the **parent shelf** (a directory) where this document belongs, judged by
+**content fit**, not by a path string that happens to match a surface word.
+
+1. **Read the document and pick the low-frequency concrete tokens.** What would actually pin the
+   right shelf is the specific stuff that appears verbatim in the body: technical slugs
+   (`page_layout`, `ImportedUserGroup`), product/tool names (`keycloak`), dates (`20230425`),
+   ticket IDs (`GW-2434`), kind-words (spec / memo / minutes / setup / dev-diary). **Prefer these
+   over topic paraphrases.** A generic topic word (the Japanese or English phrase for the
+   subject) tends to *miss* the right shelf and instead hit decoys — pages that merely *mention*
+   the topic (meeting minutes, unrelated discussions) and are a different *kind* of page.
+
+2. **grep those tokens across page bodies and see where the hits cluster.** The shelf is usually
+   the common parent directory of the strongest content-matching hits. A token that lands in one
+   tight directory is a strong signal; a token scattered across many unrelated directories is a
+   decoy — discount it.
+
+3. **A document's most unique token may return nothing — that's expected.** A coined name the
+   document itself introduces won't exist elsewhere yet (the doc is new). When that happens,
+   **pivot to the surrounding domain tokens** (the tools, the feature area, the kind-word) and
+   find the shelf through them.
+
+4. **Confirm by reading siblings, not by trusting the path name.** `ls` the candidate shelf and
+   read a sibling or two. A path/title can look right while the content is a different kind (and
+   vice versa). Reading a sibling's body is what catches a kind-mismatch and prevents a wrong
+   pick. For a box page, read its children to learn its identity.
+
+5. **Converge on 1–3 parent shelves** (directories, ending in `/`). More than one can be
+   legitimate — the correct home is not unique. Hand these to Step 2 of the main workflow as your
+   candidates (each is a directory `path`, the same shape suggest-path would return).
+
+## Depth: lean toward the shallower parent when unsure
+
+Filing the same document twice, even a careful person may not nest it the same way. If a
+candidate is right in subject and kind but you're unsure whether to go one level deeper, lean
+toward the **shallower** parent and offer the deeper one as an alternative — a too-broad parent
+still leaves room to nest later, whereas a too-narrow box can strand the document. Let the user
+make the final depth call in Step 3.
+
+**"Lean shallower" is only a tie-breaker for genuine uncertainty — it does not override a clear
+better fit.** When the wiki's habit makes one depth clearly right (e.g. a per-topic subdirectory
+already exists and holds the document's direct predecessor, so the deeper folder is unmistakably
+its home), lead with that shelf even if it is the deeper one — you are not unsure. Reserve the
+shallower default for when you genuinely cannot tell which depth this wiki would use. In both
+cases, present the other depth as the alternative so the user decides.
+
+## Filing into a personal space (`user/<name>/`)
+
+A grep can land you in someone's personal space (`user/<name>/...`) because that is where a
+matching note happens to live. Before proposing such a shelf, check **whose** space it is: a
+document should normally go into the **saving user's own** personal space, not another person's.
+Putting your note under a different user's directory is almost always wrong, even when the topic
+matches perfectly. If the best content match is in another user's space, treat that as a *signal
+about the topic* but propose the saving user's own equivalent location (or a shared shelf)
+instead — or, if you can't tell whose space it is, surface it to the user rather than filing
+silently.
+
+## A feature folder may legitimately mix kinds
+
+Don't assume one directory holds only one kind of page. A per-feature folder often gathers
+**everything** about that feature — meeting minutes, a kickoff note, and the feature's spec — all
+together. So a folder that contains minutes is not automatically a "minutes-only" decoy: if it
+also holds a spec-shaped sibling and the document is a spec for that same feature, the folder is
+the right home. Judge **per sibling**, not by the folder's first-seen page. (This is why reading
+siblings matters: it's how you tell "minutes folder, wrong kind" apart from "feature folder that
+also holds specs, right home.")
+
+## Decoys: the trap this method exists to avoid
+
+The server agent's classic failure is matching a *topic word* and proposing a shelf that shares
+the word but is the wrong **kind** (e.g. a meeting-minutes page that mentions "SAML" is not the
+home for a SAML *setup guide*). Your edge is that you can read bodies: when a grep hit is a
+different kind of page than the document, drop it even though the path string matched. Judge the
+document's kind first (is it a spec? a setup guide? a diary entry? minutes?), then keep only
+shelves consistent with that kind.
+
+## Worked sketch
+
+Document: a new "開発用の SAML セットアップ" guide (Keycloak via docker, configure GROWI security).
+
+- Concrete tokens: `keycloak`, `SAML`, `growi-client`, `realms/growi` (verbatim in the body).
+- `grep -rl "keycloak"` clusters under `Tips/開発用のミドルウェア追加/` (a predecessor SAML
+  setup page sits there), plus scattered meeting-minutes decoys.
+- `ls "Tips/開発用のミドルウェア追加/"` shows siblings: `LDAPサーバー.md`, `Basic 認証サーバー.md`,
+  `SMTP サーバー (Gmail).md` — all "dev-environment middleware setup" guides, the same kind.
+- The minutes hits under `GROWI村議議事録/` merely mention SAML → different kind → dropped.
+- Result: top shelf `/Tips/開発用のミドルウェア追加/` (with the topic subfolder as an
+  alternative). Reached via siblings, confirmed by reading their bodies — not by a path match.


### PR DESCRIPTION
## What

Adds a **Vault local-grep path discovery** mode to the `growi-smart-save` skill. When a GROWI Vault clone is reachable, the client model discovers save-path candidates by grepping the local clone of the wiki directly; otherwise it falls back to the existing server-side `suggest-path` tool. Either way the user still chooses and saves.

## Why

The server `suggest-path` agent searches Elasticsearch indirectly with a smaller model, and its weak point is *retrieval* — it tends to paraphrase the topic instead of striking the low-frequency concrete tokens (slugs, dates, IDs) that pin the right shelf. A stronger client model grepping raw Markdown hits those tokens exactly. This trades the server round-trip for direct, more reliable discovery, with the server path preserved as a safe fallback.

## Changes

- **`SKILL.md`**: Step 1 splits into **1a (Vault grep, preferred)** / **1b (server suggest-path, fallback)**. Steps 2–5 work for both. Grep-discovered candidates default to **parent-inherited grant** (the limit isn't surfaced locally); page-name proposal reuses any naming convention seen at the destination.
- **`references/vault-grep-discovery.md`** (new): the discovery method — concrete-token grep, cluster-then-read-siblings, decoy avoidance (topic-word hits of the wrong *kind*), depth/ownership/mixed-kind rules, and filename URL-decoding for path reconstruction.
- **`references/vault-clone-access.md`** (new): detect / clone / refresh via the PAT-authenticated `/vault.git` git smart-http endpoint; partial clone (`--filter=blob:none`); namespace auto-filtering by the token's permissions.

## Validation

Self-tested by handing the **skill alone** (no hand-written method) to blind agents on a real wiki clone, with each target page excluded from the clone (simulating a new, unsaved document):

- 3/3 targets: discovery succeeded from siblings only; each converged to **2 candidates** (shallower + deeper parent).
- Scored with the (separate, test-only) suggest-path evaluator: **6/6 candidates usable (○/△), zero ×, recall hit on all 3** — the ideal home was among the proposals every time.

> Note: the `suggest-path` evaluator used for scoring is a measurement tool and is not part of this PR or of production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)